### PR TITLE
Fix Safe WalletConnect typing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -299,6 +299,15 @@ const CPK = class CPK {
       address.replace(/^0x/, '').toLowerCase()
     }000000000000000000000000000000000000000000000000000000000000000001`;
 
+    const toConnectedSafeTransactions = (txs) => txs.map(({
+      operation, to, value, data,
+    }) => ({
+      operation: operation.toString(),
+      to,
+      value,
+      data,
+    }));
+
     const ownerAccount = await this.getOwnerAccount();
 
     let checkSingleCall;
@@ -350,13 +359,15 @@ const CPK = class CPK {
       attemptSafeProviderMultiSendTxs = async (txs) => {
         const hash = await (
           this.web3.currentProvider.host === 'CustomProvider'
-            ? this.web3.currentProvider.send('gs_multi_send', txs)
-            : new Promise(
+            ? this.web3.currentProvider.send(
+              'gs_multi_send',
+              toConnectedSafeTransactions(txs),
+            ) : new Promise(
               (resolve, reject) => this.web3.currentProvider.send({
                 jsonrpc: '2.0',
                 id: new Date().getTime(),
                 method: 'gs_multi_send',
-                params: txs,
+                params: toConnectedSafeTransactions(txs),
               }, (err, result) => {
                 if (err) return reject(err);
                 if (result.error) return reject(result.error);
@@ -406,7 +417,7 @@ const CPK = class CPK {
       };
 
       attemptSafeProviderMultiSendTxs = async (txs) => {
-        const hash = await this.signer.provider.send('gs_multi_send', txs);
+        const hash = await this.signer.provider.send('gs_multi_send', toConnectedSafeTransactions(txs));
         return { hash };
       };
 

--- a/test/contract-proxy-kit.js
+++ b/test/contract-proxy-kit.js
@@ -678,6 +678,12 @@ contract('CPK', ([defaultAccount, safeOwner]) => {
         }
 
         if (method === 'gs_multi_send') {
+          params.forEach((tx) => {
+            if (typeof tx.operation !== 'string') {
+              throw new Error('expected operation to be a string');
+            }
+          });
+
           const callData = multiSend.contract.methods.multiSend(
             `0x${params.map((tx) => [
               web3.eth.abi.encodeParameter('uint8', tx.operation).slice(-2),

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -19,7 +19,7 @@ const networks = Object.assign(...[
     ),
   },
 })), {
-  development: {
+  private: {
     host: 'localhost',
     port: 8545,
     network_id: '*',


### PR DESCRIPTION
The existing interface is kept, but when a WalletConnect connection with a Safe is encountered, this will coerce the operation data sent in the JSON-RPC to be a String.

Should fix #8 

I'll widen the type accepted for the operation field to be `number | string | object` as well.