### PR TITLE
Remove operation parameter for transactions for Gnosis Safe via walletconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contract-proxy-kit",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Enable batched transactions and contract account interactions using a unique deterministic Gnosis Safe.",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -300,9 +300,8 @@ const CPK = class CPK {
     }000000000000000000000000000000000000000000000000000000000000000001`;
 
     const toConnectedSafeTransactions = (txs) => txs.map(({
-      operation, to, value, data,
+      to, value, data,
     }) => ({
-      operation: operation.toString(),
       to,
       value,
       data,


### PR DESCRIPTION
The problem is that android expects operation as a string, while iOS expects operation as an integer. According to specification, `gs_multi_send` only supports CALLs and not DELEGATECALLs, so passing an operation is not needed as it will always fallback to a CALL.

More info here (also in slack):
https://github.com/gnosis/safe-android/issues/540