### PR TITLE
Add multiSend encoding static method

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,12 +270,10 @@ To run the tests locally execute the following command in the root folder of the
 yarn test
 ```
 
-To run the tests in a public network or an existing Ganache instance open the console in the root folder of the project and run the following commands:
+To run the tests against a local Ganache instance open the console in the root folder of the project and run the following commands:
 
 ```
 rm -rf build/
-yarn migrate --network <NETWORK_NAME>
-yarn test --network <NETWORK_NAME>
+yarn migrate --network local
+yarn test --network local
 ```
-
-where `<NETWORK_NAME>` is any of the networks in `truffle-config.js`.

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "dotenv": "^8.2.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.1.0",
-    "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-import": "^2.20.2",
     "ethers-4": "npm:ethers@^4.0.45",
     "should": "^13.2.3",
-    "truffle": "^5.1.18",
+    "truffle": "^5.1.19",
     "web3-1-2": "npm:web3@^1.2.6",
     "web3-2-alpha": "npm:web3@^2.0.0-alpha.1"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -178,7 +178,6 @@ const CPK = class CPK {
             web3: this.cpkProvider.web3,
             ethers: this.cpkProvider.ethers,
             signer: this.cpkProvider.signer,
-            multiSendAddress: this.cpkProvider.constructor.getContractAddress(this.multiSend),
             transactions: standardizedTxs,
           }),
           DELEGATE_CALL,
@@ -208,7 +207,6 @@ const CPK = class CPK {
           web3: this.cpkProvider.web3,
           ethers: this.cpkProvider.ethers,
           signer: this.cpkProvider.signer,
-          multiSendAddress: this.cpkProvider.constructor.getContractAddress(this.multiSend),
           transactions: standardizedTxs,
         }),
         DELEGATE_CALL,
@@ -219,32 +217,17 @@ const CPK = class CPK {
   }
 
   static async encodeMultiSendCallData({
-    web3, ethers, signer, multiSendAddress, transactions,
+    web3, ethers, signer, transactions,
   }) {
     const standardizedTxs = standarizeTransactions(transactions);
-    let multiSendAddr = multiSendAddress;
-
-    if (!multiSendAddress) {
-      let networkId;
-      if (web3) {
-        networkId = await web3.eth.net.getId();
-      } else if (ethers && signer) {
-        networkId = (await signer.provider.getNetwork()).chainId;
-      } else throw new Error('web3/ethers property missing');
-      const network = defaultNetworks[networkId];
-      if (!network) {
-        throw Error(`unrecognized network ID ${networkId}`);
-      }
-      multiSendAddr = network.multiSendAddress;
-    }
 
     if (web3) {
       return CPKWeb3Provider.encodeMultiSendCallData({
-        web3, multiSendAddress: multiSendAddr, transactions: standardizedTxs,
+        web3, transactions: standardizedTxs,
       });
     } if (ethers && signer) {
       return CPKEthersProvider.encodeMultiSendCallData({
-        ethers, signer, multiSendAddress: multiSendAddr, transactions: standardizedTxs,
+        ethers, signer, transactions: standardizedTxs,
       });
     } throw new Error('web3/ethers property missing from options');
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
 const defaultNetworks = require('./utils/networks');
-const { zeroAddress, predeterminedSaltNonce } = require('./utils/constants');
+const { zeroAddress, predeterminedSaltNonce, CALL, DELEGATE_CALL } = require('./utils/constants');
+const { standarizeTransactions } = require('./utils/transactions');
 
 const CPKWeb3Provider = require('./providers/CPKWeb3Provider');
 const CPKEthersProvider = require('./providers/CPKEthersProvider');
 
 const CPK = class CPK {
   static async create(opts) {
-    if (opts == null) throw new Error('missing options');
+    if (!opts) throw new Error('missing options');
     const cpk = new CPK(opts);
     await cpk.init();
     return cpk;
@@ -19,10 +20,10 @@ const CPK = class CPK {
     ownerAccount,
     networks,
   }) {
-    if (web3 != null) {
+    if (web3) {
       this.cpkProvider = new CPKWeb3Provider({ web3 });
-    } else if (ethers != null) {
-      if (signer == null) {
+    } else if (ethers) {
+      if (!signer) {
         throw new Error('missing signer required for ethers');
       }
       this.cpkProvider = new CPKEthersProvider({ ethers, signer });
@@ -36,11 +37,11 @@ const CPK = class CPK {
   }
 
   async init() {
-    const networkID = await this.cpkProvider.getNetworkId();
-    const network = this.networks[networkID];
+    const networkId = await this.cpkProvider.getNetworkId();
+    const network = this.networks[networkId];
 
-    if (network == null) {
-      throw Error(`unrecognized network ID ${networkID}`);
+    if (!network) {
+      throw Error(`unrecognized network ID ${networkId}`);
     }
 
     this.masterCopyAddress = network.masterCopyAddress;
@@ -94,19 +95,14 @@ const CPK = class CPK {
     const codeAtAddress = await this.cpkProvider.getCodeAtAddress(this.contract);
     const sendOptions = await this.cpkProvider.constructor.getSendOptions(options, ownerAccount);
 
-    const standardizedTxs = transactions.map((tx) => ({
-      value: tx.value ? tx.value : 0,
-      data: tx.data ? tx.data : '0x',
-      operation: tx.operation ? tx.operation : CPK.CALL,
-      ...tx,
-    }));
+    const standardizedTxs = standarizeTransactions(transactions);
 
     if (standardizedTxs.length === 1) {
       const {
         to, value, data, operation,
       } = standardizedTxs[0];
 
-      if (operation === CPK.CALL) {
+      if (operation === CALL) {
         await this.cpkProvider.checkSingleCall(this.address, to, value, data);
 
         if (this.isConnectedToSafe) {
@@ -209,7 +205,7 @@ const CPK = class CPK {
   }
 };
 
-CPK.CALL = 0;
-CPK.DELEGATECALL = 1;
+CPK.CALL = CALL;
+CPK.DELEGATECALL = DELEGATE_CALL;
 
 module.exports = CPK;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 const defaultNetworks = require('./utils/networks');
-const { zeroAddress, predeterminedSaltNonce, CALL, DELEGATE_CALL } = require('./utils/constants');
+const {
+  zeroAddress, predeterminedSaltNonce, CALL, DELEGATE_CALL,
+} = require('./utils/constants');
 const { standarizeTransactions } = require('./utils/transactions');
 
 const CPKWeb3Provider = require('./providers/CPKWeb3Provider');
@@ -177,7 +179,7 @@ const CPK = class CPK {
             ethers: this.cpkProvider.ethers,
             signer: this.cpkProvider.signer,
             multiSendAddress: this.cpkProvider.constructor.getContractAddress(this.multiSend),
-            transactions: standardizedTxs
+            transactions: standardizedTxs,
           }),
           DELEGATE_CALL,
           0,
@@ -207,7 +209,7 @@ const CPK = class CPK {
           ethers: this.cpkProvider.ethers,
           signer: this.cpkProvider.signer,
           multiSendAddress: this.cpkProvider.constructor.getContractAddress(this.multiSend),
-          transactions: standardizedTxs
+          transactions: standardizedTxs,
         }),
         DELEGATE_CALL,
       ],
@@ -216,18 +218,20 @@ const CPK = class CPK {
     );
   }
 
-  static async encodeMultiSendCallData({ web3, ethers, signer, multiSendAddress, transactions }) {
+  static async encodeMultiSendCallData({
+    web3, ethers, signer, multiSendAddress, transactions,
+  }) {
     const standardizedTxs = standarizeTransactions(transactions);
-    let multiSendAddr = multiSendAddress
+    let multiSendAddr = multiSendAddress;
 
     if (!multiSendAddress) {
-      let networkId
+      let networkId;
       if (web3) {
         networkId = await web3.eth.net.getId();
       } else if (ethers && signer) {
         networkId = (await signer.provider.getNetwork()).chainId;
       } else throw new Error('web3/ethers property missing');
-      const network = defaultNetworks[networkId]
+      const network = defaultNetworks[networkId];
       if (!network) {
         throw Error(`unrecognized network ID ${networkId}`);
       }
@@ -235,10 +239,14 @@ const CPK = class CPK {
     }
 
     if (web3) {
-      return CPKWeb3Provider.encodeMultiSendCallData({ web3, multiSendAddress: multiSendAddr, transactions: standardizedTxs });
-    } else if (ethers && signer) {
-      return CPKEthersProvider.encodeMultiSendCallData({ ethers, signer, multiSendAddress: multiSendAddr, transactions: standardizedTxs });
-    } else throw new Error('web3/ethers property missing from options');
+      return CPKWeb3Provider.encodeMultiSendCallData({
+        web3, multiSendAddress: multiSendAddr, transactions: standardizedTxs,
+      });
+    } if (ethers && signer) {
+      return CPKEthersProvider.encodeMultiSendCallData({
+        ethers, signer, multiSendAddress: multiSendAddr, transactions: standardizedTxs,
+      });
+    } throw new Error('web3/ethers property missing from options');
   }
 };
 

--- a/src/providers/CPKEthersProvider.js
+++ b/src/providers/CPKEthersProvider.js
@@ -133,18 +133,20 @@ class CPKEthersProvider extends CPKProvider {
     return { hash };
   }
 
-  encodeMultiSendCalldata(multiSend, txs) {
+  static encodeMultiSendCallData({ ethers, signer, transactions, multiSendAddress }) {
+    const multiSend = new ethers.Contract(multiSendAddress, multiSendAbi, signer);
+
     return multiSend.interface.functions.multiSend.encode([
-      this.ethers.utils.hexlify(
-        this.ethers.utils.concat(
-          txs.map(
-            (tx) => this.ethers.utils.solidityPack(
+      ethers.utils.hexlify(
+        ethers.utils.concat(
+          transactions.map(
+            (tx) => ethers.utils.solidityPack(
               ['uint8', 'address', 'uint256', 'uint256', 'bytes'],
               [
                 tx.operation,
                 tx.to,
                 tx.value,
-                this.ethers.utils.hexDataLength(tx.data),
+                ethers.utils.hexDataLength(tx.data),
                 tx.data,
               ],
             ),

--- a/src/providers/CPKEthersProvider.js
+++ b/src/providers/CPKEthersProvider.js
@@ -7,7 +7,7 @@ const multiSendAbi = require('../abis/MultiSendAbi.json');
 class CPKEthersProvider extends CPKProvider {
   constructor({ ethers, signer }) {
     super();
-    if (signer == null) {
+    if (!signer) {
       throw new Error('missing signer required for ethers');
     }
     this.ethers = ethers;
@@ -115,7 +115,7 @@ class CPKEthersProvider extends CPKProvider {
     if (!(await viewContract.functions[methodName](...params))) throw err;
     const transactionResponse = await contract.functions[methodName](
       ...params,
-      ...(options == null ? [] : [options]),
+      ...(!options ? [] : [options]),
     );
     return { transactionResponse, hash: transactionResponse.hash };
   }

--- a/src/providers/CPKEthersProvider.js
+++ b/src/providers/CPKEthersProvider.js
@@ -1,5 +1,5 @@
 const CPKProvider = require('./CPKProvider');
-const { predeterminedSaltNonce } = require('../utils/constants');
+const { zeroAddress, predeterminedSaltNonce } = require('../utils/constants');
 const cpkFactoryAbi = require('../abis/CpkFactoryAbi.json');
 const safeAbi = require('../abis/SafeAbi.json');
 const multiSendAbi = require('../abis/MultiSendAbi.json');
@@ -133,10 +133,8 @@ class CPKEthersProvider extends CPKProvider {
     return { hash };
   }
 
-  static encodeMultiSendCallData({
-    ethers, signer, transactions, multiSendAddress,
-  }) {
-    const multiSend = new ethers.Contract(multiSendAddress, multiSendAbi, signer);
+  static encodeMultiSendCallData({ ethers, signer, transactions }) {
+    const multiSend = new ethers.Contract(zeroAddress, multiSendAbi, signer);
 
     return multiSend.interface.functions.multiSend.encode([
       ethers.utils.hexlify(

--- a/src/providers/CPKEthersProvider.js
+++ b/src/providers/CPKEthersProvider.js
@@ -133,7 +133,9 @@ class CPKEthersProvider extends CPKProvider {
     return { hash };
   }
 
-  static encodeMultiSendCallData({ ethers, signer, transactions, multiSendAddress }) {
+  static encodeMultiSendCallData({
+    ethers, signer, transactions, multiSendAddress,
+  }) {
     const multiSend = new ethers.Contract(multiSendAddress, multiSendAbi, signer);
 
     return multiSend.interface.functions.multiSend.encode([

--- a/src/providers/CPKWeb3Provider.js
+++ b/src/providers/CPKWeb3Provider.js
@@ -122,8 +122,8 @@ class CPKWeb3Provider extends CPKProvider {
     return { hash };
   }
 
-  static encodeMultiSendCallData({ web3, transactions, multiSendAddress }) {
-    const multiSend = new web3.eth.Contract(multiSendAbi, multiSendAddress);
+  static encodeMultiSendCallData({ web3, transactions }) {
+    const multiSend = new web3.eth.Contract(multiSendAbi);
 
     return multiSend.methods.multiSend(
       `0x${transactions.map((tx) => [

--- a/src/providers/CPKWeb3Provider.js
+++ b/src/providers/CPKWeb3Provider.js
@@ -122,13 +122,15 @@ class CPKWeb3Provider extends CPKProvider {
     return { hash };
   }
 
-  encodeMultiSendCalldata(multiSend, txs) {
+  static encodeMultiSendCallData({ web3, transactions, multiSendAddress }) {
+    const multiSend = new web3.eth.Contract(multiSendAbi, multiSendAddress);
+
     return multiSend.methods.multiSend(
-      `0x${txs.map((tx) => [
-        this.web3.eth.abi.encodeParameter('uint8', tx.operation).slice(-2),
-        this.web3.eth.abi.encodeParameter('address', tx.to).slice(-40),
-        this.web3.eth.abi.encodeParameter('uint256', tx.value).slice(-64),
-        this.web3.eth.abi.encodeParameter('uint256', this.web3.utils.hexToBytes(tx.data).length).slice(-64),
+      `0x${transactions.map((tx) => [
+        web3.eth.abi.encodeParameter('uint8', tx.operation).slice(-2),
+        web3.eth.abi.encodeParameter('address', tx.to).slice(-40),
+        web3.eth.abi.encodeParameter('uint256', tx.value).slice(-64),
+        web3.eth.abi.encodeParameter('uint256', web3.utils.hexToBytes(tx.data).length).slice(-64),
         tx.data.replace(/^0x/, ''),
       ].join('')).join('')}`,
     ).encodeABI();

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,9 +1,21 @@
+const CALL = 0;
+const DELEGATE_CALL = 1;
+
 const zeroAddress = `0x${'0'.repeat(40)}`;
+
+const defaultTxOperation = CALL;
+const defaultTxValue = 0;
+const defaultTxData = '0x';
 
 // keccak256(toUtf8Bytes('Contract Proxy Kit'))
 const predeterminedSaltNonce = '0xcfe33a586323e7325be6aa6ecd8b4600d232a9037e83c8ece69413b777dabe65';
 
 module.exports = {
+  CALL,
+  DELEGATE_CALL,
+  defaultTxOperation,
+  defaultTxValue,
+  defaultTxData,
   zeroAddress,
   predeterminedSaltNonce,
 };

--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -1,13 +1,11 @@
 const { defaultTxData, defaultTxOperation, defaultTxValue } = require('./constants');
 
-const standarizeTransactions = (transactions) => {
-  return transactions.map((tx) => ({
-    data: tx.data ? tx.data : defaultTxData,
-    operation: tx.operation ? tx.operation : defaultTxOperation,
-    value: tx.value ? tx.value : defaultTxValue,
-    ...tx,
-  }));
-}
+const standarizeTransactions = (transactions) => transactions.map((tx) => ({
+  data: tx.data ? tx.data : defaultTxData,
+  operation: tx.operation ? tx.operation : defaultTxOperation,
+  value: tx.value ? tx.value : defaultTxValue,
+  ...tx,
+}));
 
 
 module.exports = {

--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -1,0 +1,15 @@
+const { defaultTxData, defaultTxOperation, defaultTxValue } = require('./constants');
+
+const standarizeTransactions = (transactions) => {
+  return transactions.map((tx) => ({
+    data: tx.data ? tx.data : defaultTxData,
+    operation: tx.operation ? tx.operation : defaultTxOperation,
+    value: tx.value ? tx.value : defaultTxValue,
+    ...tx,
+  }));
+}
+
+
+module.exports = {
+  standarizeTransactions,
+};

--- a/test/ethers/shouldWorkWithEthers.js
+++ b/test/ethers/shouldWorkWithEthers.js
@@ -56,7 +56,7 @@ function shouldWorkWithEthers(ethers, defaultAccount, safeOwner, gnosisSafeProvi
       await CPK.encodeMultiSendCallData({
         ethers,
         signer,
-        transactions
+        transactions,
       }).should.be.rejectedWith(/unrecognized network ID \d+/);
     });
 
@@ -79,7 +79,7 @@ function shouldWorkWithEthers(ethers, defaultAccount, safeOwner, gnosisSafeProvi
       });
 
       it('can encode multiSend call data with custom multiSend address', async () => {
-        const multiStepAddress = multiStep.address.slice(2).toLowerCase()
+        const multiStepAddress = multiStep.address.slice(2).toLowerCase();
         const transactions = [{
           to: multiStep.address,
           data: multiStep.contract.methods.doStep(1).encodeABI(),
@@ -92,9 +92,9 @@ function shouldWorkWithEthers(ethers, defaultAccount, safeOwner, gnosisSafeProvi
           ethers,
           signer,
           multiSendAddress: networks[(await signer.provider.getNetwork()).chainId].multiSendAddress,
-          transactions
+          transactions,
         });
-  
+
         dataHash.should.be.equal(`0x8d80ff0a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000f200${multiStepAddress}00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024c01cf093000000000000000000000000000000000000000000000000000000000000000100${multiStepAddress}00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024c01cf09300000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000`);
       });
 

--- a/test/ethers/shouldWorkWithEthers.js
+++ b/test/ethers/shouldWorkWithEthers.js
@@ -44,22 +44,6 @@ function shouldWorkWithEthers(ethers, defaultAccount, safeOwner, gnosisSafeProvi
       await CPK.create({ ethers, signer }).should.be.rejectedWith(/unrecognized network ID \d+/);
     });
 
-    it('should not encode multiSend call data without custom multiSend address when ethers not connected to a recognized network', async () => {
-      const transactions = [{
-        to: multiStep.address,
-        data: multiStep.contract.methods.doStep(1).encodeABI(),
-      }, {
-        to: multiStep.address,
-        data: multiStep.contract.methods.doStep(2).encodeABI(),
-      }];
-
-      await CPK.encodeMultiSendCallData({
-        ethers,
-        signer,
-        transactions,
-      }).should.be.rejectedWith(/unrecognized network ID \d+/);
-    });
-
     describe('with valid networks configuration', () => {
       let networks;
 
@@ -78,7 +62,7 @@ function shouldWorkWithEthers(ethers, defaultAccount, safeOwner, gnosisSafeProvi
         should.exist(await CPK.create({ ethers, signer, networks }));
       });
 
-      it('can encode multiSend call data with custom multiSend address', async () => {
+      it('can encode multiSend call data', async () => {
         const multiStepAddress = multiStep.address.slice(2).toLowerCase();
         const transactions = [{
           to: multiStep.address,
@@ -91,7 +75,6 @@ function shouldWorkWithEthers(ethers, defaultAccount, safeOwner, gnosisSafeProvi
         const dataHash = await CPK.encodeMultiSendCallData({
           ethers,
           signer,
-          multiSendAddress: networks[(await signer.provider.getNetwork()).chainId].multiSendAddress,
           transactions,
         });
 

--- a/test/web3/shouldWorkWithWeb3.js
+++ b/test/web3/shouldWorkWithWeb3.js
@@ -55,7 +55,7 @@ function shouldWorkWithWeb3(Web3, defaultAccount, safeOwner, gnosisSafeProviderB
 
       await CPK.encodeMultiSendCallData({
         web3: ueb3,
-        transactions
+        transactions,
       }).should.be.rejectedWith(/unrecognized network ID \d+/);
     });
 
@@ -78,7 +78,7 @@ function shouldWorkWithWeb3(Web3, defaultAccount, safeOwner, gnosisSafeProviderB
       });
 
       it('can encode multiSend call data with custom multiSend address', async () => {
-        const multiStepAddress = multiStep.address.slice(2).toLowerCase()
+        const multiStepAddress = multiStep.address.slice(2).toLowerCase();
         const transactions = [{
           to: multiStep.address,
           data: multiStep.contract.methods.doStep(1).encodeABI(),
@@ -90,9 +90,9 @@ function shouldWorkWithWeb3(Web3, defaultAccount, safeOwner, gnosisSafeProviderB
         const dataHash = await CPK.encodeMultiSendCallData({
           web3: ueb3,
           multiSendAddress: networks[await ueb3.eth.net.getId()].multiSendAddress,
-          transactions
+          transactions,
         });
-  
+
         dataHash.should.be.equal(`0x8d80ff0a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000f200${multiStepAddress}00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024c01cf093000000000000000000000000000000000000000000000000000000000000000100${multiStepAddress}00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024c01cf09300000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000`);
       });
 

--- a/test/web3/shouldWorkWithWeb3.js
+++ b/test/web3/shouldWorkWithWeb3.js
@@ -44,21 +44,6 @@ function shouldWorkWithWeb3(Web3, defaultAccount, safeOwner, gnosisSafeProviderB
       await CPK.create({ web3: ueb3 }).should.be.rejectedWith(/unrecognized network ID \d+/);
     });
 
-    it('should not encode multiSend call data without custom multiSend address when web3 not connected to a recognized network', async () => {
-      const transactions = [{
-        to: multiStep.address,
-        data: multiStep.contract.methods.doStep(1).encodeABI(),
-      }, {
-        to: multiStep.address,
-        data: multiStep.contract.methods.doStep(2).encodeABI(),
-      }];
-
-      await CPK.encodeMultiSendCallData({
-        web3: ueb3,
-        transactions,
-      }).should.be.rejectedWith(/unrecognized network ID \d+/);
-    });
-
     describe('with valid networks configuration', () => {
       let networks;
 
@@ -89,7 +74,6 @@ function shouldWorkWithWeb3(Web3, defaultAccount, safeOwner, gnosisSafeProviderB
 
         const dataHash = await CPK.encodeMultiSendCallData({
           web3: ueb3,
-          multiSendAddress: networks[await ueb3.eth.net.getId()].multiSendAddress,
           transactions,
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2221,10 +2221,10 @@ eslint-module-utils@^2.4.1:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-import@^2.20.1:
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz#802423196dcb11d9ce8435a5fc02a6d3b46939b3"
-  integrity sha512-qQHgFOTjguR+LnYRoToeZWT62XM55MBVXObHM6SKFd1VzDcX/vqT1kAz8ssqigh5eMj8qXcRoXXGZpPP6RfdCw==
+eslint-plugin-import@^2.20.2:
+  version "2.20.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.20.2.tgz#91fc3807ce08be4837141272c8b99073906e588d"
+  integrity sha512-FObidqpXrR8OnCh4iNsxy+WACztJLXAHBO5hK79T1Hc77PgQZkyDGA5Ag9xAvRpglvLNxhH/zSmZ70/pZ31dHg==
   dependencies:
     array-includes "^3.0.3"
     array.prototype.flat "^1.2.1"
@@ -6499,10 +6499,10 @@ truffle-hdwallet-provider@0.0.7-beta.1:
     web3 "^0.18.2"
     web3-provider-engine "^14.0.5"
 
-truffle@^5.1.18:
-  version "5.1.18"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.1.18.tgz#2fefaed849698b7fb865b417a197d1b6d9229db3"
-  integrity sha512-9oxmLmyTXML5Auxl8adPd3kLcOZVhYNapCmPUcMnYCOXthxa3NEOW9y3PTcoDnwFyuIOETGIiJp4Ew9bmY8v6Q==
+truffle@^5.1.19:
+  version "5.1.19"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.1.19.tgz#daf0aca071b9e2cdd88f456f10c1a81e840794aa"
+  integrity sha512-H4S7GbKCN56eW5ftLo+l160c+SLyF8C205hUF9VRfulxFBdXvmTIeHdRO/zcnBWiKfEbXzuHWSI9gyFkPtkvmw==
   dependencies:
     app-module-path "^2.2.0"
     mocha "5.2.0"


### PR DESCRIPTION
This PR adds the static method `encodeMultiSendCallData` to the contract-proxy-kit