### PR TITLE
Estimate tx gas

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,14 +280,6 @@ To run the tests locally execute the following command in the root folder of the
 yarn test
 ```
 
-To run the tests against a local Ganache instance open the console in the root folder of the project and run the following commands:
-
-```
-rm -rf build/
-yarn migrate --network local
-yarn test --network local
-```
-
 ## In-depth Guide
 
 The Contract Proxy Kit operates primarily using the following technologies:

--- a/package.json
+++ b/package.json
@@ -49,8 +49,5 @@
     "typescript": "^3.8.3",
     "web3-1-2": "npm:web3@^1.2.6",
     "web3-2-alpha": "npm:web3@^2.0.0-alpha.1"
-  },
-  "dependencies": {
-    "bignumber.js": "^9.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "migrate": "truffle migrate",
     "test-norpc": "truffle test",
-    "test": "run(){ run-with-testrpc -l 20000000 --noVMErrorsOnRPCResponse \"truffle test $@\"; }; run",
+    "test": "run(){ run-with-testrpc -l 20000000 --noVMErrorsOnRPCResponse \"truffle test --network local $@\"; }; run",
     "lint:check": "eslint './src/**/*.{js,jsx}' './test/**/*.{js,jsx}'",
     "lint:fix": "yarn lint:check --fix",
     "build": "tsc"

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "typescript": "^3.8.3",
     "web3-1-2": "npm:web3@^1.2.6",
     "web3-2-alpha": "npm:web3@^2.0.0-alpha.1"
+  },
+  "dependencies": {
+    "bignumber.js": "^9.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "src/index.ts",
   "scripts": {
     "migrate": "truffle migrate",
-    "test": "truffle test",
-    "lint:check": "eslint './src/**/*.{js,ts}'",
+    "test-norpc": "truffle test",
+    "test": "run(){ run-with-testrpc -l 20000000 --noVMErrorsOnRPCResponse \"truffle test $@\"; }; run",
+    "lint:check": "eslint './src/**/*.{js,jsx}' './test/**/*.{js,jsx}'",
     "lint:fix": "yarn lint:check --fix",
     "build": "tsc"
   },
@@ -41,6 +42,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^6.8.0",
     "ethers-4": "npm:ethers@^4.0.45",
+    "run-with-testrpc": "^0.3.1",
     "should": "^13.2.3",
     "truffle": "^5.1.22",
     "ts-node": "^8.8.2",

--- a/src/abis/CpkFactoryAbi.json
+++ b/src/abis/CpkFactoryAbi.json
@@ -1,30 +1,68 @@
 [
   {
-    "type": "function",
-    "name": "proxyCreationCode",
     "constant": true,
+    "inputs": [],
+    "name": "proxyCreationCode",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
     "payable": false,
     "stateMutability": "pure",
-    "inputs": [],
-    "outputs": [{ "type": "bytes", "name": "" }]
+    "type": "function"
   },
   {
-    "type": "function",
-    "name": "createProxyAndExecTransaction",
     "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "masterCopy",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "saltNonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "fallbackHandler",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "enum Enum.Operation",
+        "name": "operation",
+        "type": "uint8"
+      }
+    ],
+    "name": "createProxyAndExecTransaction",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "execTransactionSuccess",
+        "type": "bool"
+      }
+    ],
     "payable": false,
     "stateMutability": "nonpayable",
-    "inputs": [
-      { "type": "address", "name": "masterCopy" },
-      { "type": "uint256", "name": "saltNonce" },
-      { "type": "address", "name": "fallbackHandler" },
-      { "type": "address", "name": "to" },
-      { "type": "uint256", "name": "value" },
-      { "type": "bytes", "name": "data" },
-      { "type": "uint8", "name": "operation" }
-    ],
-    "outputs": [
-      { "type": "bool", "name": "execTransactionSuccess" }
-    ]
+    "type": "function"
   }
 ]

--- a/src/abis/MultiSendAbi.json
+++ b/src/abis/MultiSendAbi.json
@@ -1,13 +1,17 @@
 [
   {
-    "type": "function",
-    "name": "multiSend",
     "constant": false,
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "transactions",
+        "type": "bytes"
+      }
+    ],
+    "name": "multiSend",
+    "outputs": [],
     "payable": false,
     "stateMutability": "nonpayable",
-    "inputs": [
-      { "type": "bytes", "name": "transactions" }
-    ],
-    "outputs": []
+    "type": "function"
   }
 ]

--- a/src/abis/SafeAbi.json
+++ b/src/abis/SafeAbi.json
@@ -1,51 +1,153 @@
+
 [
   {
-    "type": "function",
-    "name": "setup",
     "constant": false,
-    "payable": false,
-    "stateMutability": "nonpayable",
     "inputs": [
-      { "type": "address[]", "name": "owners" },
-      { "type": "uint256", "name": "threshold" },
-      { "type": "address", "name": "to" },
-      { "type": "bytes", "name": "data" },
-      { "type": "address", "name": "fallbackHandler" },
-      { "type": "address", "name": "paymentToken" },
-      { "type": "uint256", "name": "payment" },
-      { "type": "address", "name": "paymentReceiver" }
-    ]
-  },
-  {
-    "type": "function",
-    "name": "execTransaction",
-    "constant": false,
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "inputs": [
-      { "type": "address", "name": "to" },
-      { "type": "uint256", "name": "value" },
-      { "type": "bytes", "name": "data" },
-      { "type": "uint8", "name": "operation" },
-      { "type": "uint256", "name": "safeTxGas" },
-      { "type": "uint256", "name": "baseGas" },
-      { "type": "uint256", "name": "gasPrice" },
-      { "type": "address", "name": "gasToken" },
-      { "type": "address", "name": "refundReceiver" },
-      { "type": "bytes", "name": "signatures" }
+      {
+        "name": "_owners",
+        "type": "address[]"
+      },
+      {
+        "name": "_threshold",
+        "type": "uint256"
+      },
+      {
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "name": "fallbackHandler",
+        "type": "address"
+      },
+      {
+        "name": "paymentToken",
+        "type": "address"
+      },
+      {
+        "name": "payment",
+        "type": "uint256"
+      },
+      {
+        "name": "paymentReceiver",
+        "type": "address"
+      }
     ],
-    "outputs": [{ "type": "bool", "name": "success" }]
-  },
-  {
-    "type": "function",
-    "name": "swapOwner",
-    "constant": false,
+    "name": "setup",
+    "outputs": [],
     "payable": false,
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
     "inputs": [
-      { "type": "address", "name": "prevOwner" },
-      { "type": "address", "name": "oldOwner" },
-      { "type": "address", "name": "newOwner" }
-    ]
+      {
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "name": "operation",
+        "type": "uint8"
+      },
+      {
+        "name": "safeTxGas",
+        "type": "uint256"
+      },
+      {
+        "name": "baseGas",
+        "type": "uint256"
+      },
+      {
+        "name": "gasPrice",
+        "type": "uint256"
+      },
+      {
+        "name": "gasToken",
+        "type": "address"
+      },
+      {
+        "name": "refundReceiver",
+        "type": "address"
+      },
+      {
+        "name": "signatures",
+        "type": "bytes"
+      }
+    ],
+    "name": "execTransaction",
+    "outputs": [
+      {
+        "name": "success",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "prevOwner",
+        "type": "address"
+      },
+      {
+        "name": "oldOwner",
+        "type": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "swapOwner",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+{
+    "constant": false,
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "name": "operation",
+        "type": "uint8"
+      }
+    ],
+    "name": "requiredTxGas",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
   }
 ]

--- a/src/abis/SafeAbi.json
+++ b/src/abis/SafeAbi.json
@@ -1,6 +1,21 @@
 
 [
   {
+    "constant": true,
+    "inputs": [],
+    "name": "nonce",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "constant": false,
     "inputs": [
       {

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ class CPK {
             operation,
           );
 
-          return this.cpkProvider.attemptTransaction(
+          return this.cpkProvider.constructor.attemptTransaction(
             this.contract,
             this.viewContract,
             'execTransaction',
@@ -165,7 +165,7 @@ class CPK {
           );
         }
 
-        return this.cpkProvider.attemptTransaction(
+        return this.cpkProvider.constructor.attemptTransaction(
           this.proxyFactory,
           this.viewProxyFactory,
           'createProxyAndExecTransaction',
@@ -213,7 +213,7 @@ class CPK {
         operation,
       );
 
-      return this.cpkProvider.attemptTransaction(
+      return this.cpkProvider.constructor.attemptTransaction(
         this.contract,
         this.viewContract,
         'execTransaction',
@@ -234,7 +234,7 @@ class CPK {
       );
     }
 
-    return this.cpkProvider.attemptTransaction(
+    return this.cpkProvider.constructor.attemptTransaction(
       this.proxyFactory,
       this.viewProxyFactory,
       'createProxyAndExecTransaction',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { OperationType, zeroAddress, predeterminedSaltNonce } from './utils/constants';
 import { defaultNetworks, NetworksConfig } from './utils/networks';
 import { standardizeTransactions, SafeProviderSendTransaction, NonStandardTransaction } from './utils/transactions';
+const { estimateSafeTxGas } = require('./utils');
 import CPKProvider from './providers/CPKProvider';
 
 interface CPKConfig {
@@ -117,7 +118,12 @@ class CPK {
       } = standardizeTransactions(transactions)[0];
 
       if (operation === CPK.Call) {
-        await this.cpkProvider.checkSingleCall(this.address, to, value, data);
+        await this.cpkProvider.checkSingleCall({
+          from: this.address,
+          to,
+          value,
+          data,
+        });
 
         if (this.isConnectedToSafe) {
           return this.cpkProvider.attemptSafeProviderSendTx({ to, value, data }, sendOptions);
@@ -126,6 +132,15 @@ class CPK {
 
       if (!this.isConnectedToSafe) {
         if (codeAtAddress !== '0x') {
+          const safeTxGas = await estimateSafeTxGas(
+            this.cpkProvider,
+            this.address,
+            data,
+            to,
+            value,
+            operation,
+          );
+
           return this.cpkProvider.attemptTransaction(
             this.contract,
             this.viewContract,
@@ -135,7 +150,7 @@ class CPK {
               value,
               data,
               operation,
-              0,
+              safeTxGas,
               0,
               0,
               zeroAddress,
@@ -180,16 +195,30 @@ class CPK {
     }
 
     if (codeAtAddress !== '0x') {
+      const to = this.cpkProvider.getContractAddress(this.multiSend);
+      const value = 0;
+      const data = this.cpkProvider.encodeMultiSendCallData(transactions);
+      const operation = CPK.DelegateCall;
+
+      const safeTxGas = await estimateSafeTxGas(
+        this.cpkProvider,
+        this.address,
+        data,
+        to,
+        value,
+        operation,
+      );
+
       return this.cpkProvider.attemptTransaction(
         this.contract,
         this.viewContract,
         'execTransaction',
         [
-          this.cpkProvider.getContractAddress(this.multiSend),
-          0,
-          this.cpkProvider.encodeMultiSendCallData(transactions),
-          CPK.DelegateCall,
-          0,
+          to,
+          value,
+          data,
+          operation,
+          safeTxGas,
           0,
           0,
           zeroAddress,

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,8 +108,6 @@ class CPK {
       address.replace(/^0x/, '').toLowerCase()
     }000000000000000000000000000000000000000000000000000000000000000001`;
 
-    const signatureCount = 1;
-
     const ownerAccount = await this.getOwnerAccount();
     const codeAtAddress = await this.cpkProvider.getCodeAtAddress(this.contract);
     const sendOptions = await this.cpkProvider.getSendOptions(options, ownerAccount);
@@ -137,7 +135,6 @@ class CPK {
           const { safeTxGas, baseGas } = await estimateSafeTxGas(
             this.cpkProvider,
             this.address,
-            signatureCount,
             data,
             to,
             value,
@@ -206,7 +203,6 @@ class CPK {
       const { safeTxGas, baseGas } = await estimateSafeTxGas(
         this.cpkProvider,
         this.address,
-        signatureCount,
         data,
         to,
         value,

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,8 @@ class CPK {
       address.replace(/^0x/, '').toLowerCase()
     }000000000000000000000000000000000000000000000000000000000000000001`;
 
+    const signatureCount = 1;
+
     const ownerAccount = await this.getOwnerAccount();
     const codeAtAddress = await this.cpkProvider.getCodeAtAddress(this.contract);
     const sendOptions = await this.cpkProvider.getSendOptions(options, ownerAccount);
@@ -132,9 +134,10 @@ class CPK {
 
       if (!this.isConnectedToSafe) {
         if (codeAtAddress !== '0x') {
-          const safeTxGas = await estimateSafeTxGas(
+          const { safeTxGas, baseGas } = await estimateSafeTxGas(
             this.cpkProvider,
             this.address,
+            signatureCount,
             data,
             to,
             value,
@@ -151,7 +154,7 @@ class CPK {
               data,
               operation,
               safeTxGas,
-              0,
+              baseGas,
               0,
               zeroAddress,
               zeroAddress,
@@ -200,9 +203,10 @@ class CPK {
       const data = this.cpkProvider.encodeMultiSendCallData(transactions);
       const operation = CPK.DelegateCall;
 
-      const safeTxGas = await estimateSafeTxGas(
+      const { safeTxGas, baseGas } = await estimateSafeTxGas(
         this.cpkProvider,
         this.address,
+        signatureCount,
         data,
         to,
         value,
@@ -219,7 +223,7 @@ class CPK {
           data,
           operation,
           safeTxGas,
-          0,
+          baseGas,
           0,
           zeroAddress,
           zeroAddress,

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ class CPK {
             operation,
           );
 
-          return this.cpkProvider.constructor.attemptTransaction(
+          return this.cpkProvider.attemptTransaction(
             this.contract,
             this.viewContract,
             'execTransaction',
@@ -162,7 +162,7 @@ class CPK {
           );
         }
 
-        return this.cpkProvider.constructor.attemptTransaction(
+        return this.cpkProvider.attemptTransaction(
           this.proxyFactory,
           this.viewProxyFactory,
           'createProxyAndExecTransaction',
@@ -209,7 +209,7 @@ class CPK {
         operation,
       );
 
-      return this.cpkProvider.constructor.attemptTransaction(
+      return this.cpkProvider.attemptTransaction(
         this.contract,
         this.viewContract,
         'execTransaction',
@@ -230,7 +230,7 @@ class CPK {
       );
     }
 
-    return this.cpkProvider.constructor.attemptTransaction(
+    return this.cpkProvider.attemptTransaction(
       this.proxyFactory,
       this.viewProxyFactory,
       'createProxyAndExecTransaction',

--- a/src/providers/CPKEthersProvider.ts
+++ b/src/providers/CPKEthersProvider.ts
@@ -157,18 +157,30 @@ class CPKEthersProvider implements CPKProvider {
     }
   }
 
-  async attemptTransaction(
+  async checkMethod(
     contract: any,
     viewContract: any,
     methodName: string,
     params: Array<any>,
-    options: object,
-    err: Error
-  ): Promise<EthersTransactionResult> {
+    sendOptions: {
+      gasLimit?: number | string;
+    },
+    err: Error,
+  ): Promise<void> {
     if (!(await viewContract.functions[methodName](...params))) throw err;
+  }
+
+  async execMethod(
+    contract: any,
+    methodName: string,
+    params: Array<any>,
+    sendOptions: {
+      gasLimit?: number | string;
+    }
+  ): Promise<EthersTransactionResult> {
     const transactionResponse = await contract.functions[methodName](
       ...params,
-      ...(!options ? [] : [options]),
+      ...(!sendOptions ? [] : [sendOptions]),
     );
     return { transactionResponse, hash: transactionResponse.hash };
   }

--- a/src/providers/CPKEthersProvider.ts
+++ b/src/providers/CPKEthersProvider.ts
@@ -144,6 +144,12 @@ class CPKEthersProvider implements CPKProvider {
     return { transactionResponse, hash: transactionResponse.hash };
   }
 
+  encodeAttemptTransaction(contractAbi: object[], methodName: string, params: any[]): string {
+    const iface = new this.ethers.utils.Interface(contractAbi);
+    const payload = iface.functions[methodName].encode(params);
+    return payload;
+  }
+
   async attemptSafeProviderSendTx(
     txObj: SafeProviderSendTransaction,
     options: object
@@ -189,6 +195,17 @@ class CPKEthersProvider implements CPKProvider {
   // eslint-disable-next-line
   getSendOptions(options: object, ownerAccount: string): object {
     return options;
+  }
+
+  async getGasPrice(): Promise<number> {
+    const gasPrice = await this.signer.provider.getGasPrice();
+    return gasPrice.toNumber();
+  }
+
+  async getSafeNonce(safeAddress: string): Promise<number> {
+    const safeContract = this.getContract(safeAbi, safeAddress);
+    const nonce = (await safeContract.nonce()).toNumber();
+    return nonce;
   }
 }
 

--- a/src/providers/CPKEthersProvider.ts
+++ b/src/providers/CPKEthersProvider.ts
@@ -133,8 +133,9 @@ class CPKEthersProvider implements CPKProvider {
   }: {
     from: string;
     to: string;
-    value: number | string;
+    value?: number | string;
     data: string;
+    gasLimit?: number | string;
   }): Promise<string> {
     try {
       // Handle Geth/Ganache --noVMErrorsOnRPCResponse revert data

--- a/src/providers/CPKProvider.ts
+++ b/src/providers/CPKProvider.ts
@@ -37,9 +37,16 @@ interface CPKProvider {
 
   getCodeAtAddress(contract: any): Promise<string>;
 
+  getContract(abi: Array<object>, address: string): any;
+
   getContractAddress(contract: any): string;
 
-  checkSingleCall(from: string, to: string, value: number | string, data: string): Promise<any>;
+  checkSingleCall(opts: {
+    from: string;
+    to: string;
+    value: number | string;
+    data: string;
+  }): Promise<any>;
 
   attemptTransaction(
     contract: any,

--- a/src/providers/CPKProvider.ts
+++ b/src/providers/CPKProvider.ts
@@ -56,14 +56,25 @@ interface CPKProvider {
     gasLimit?: number | string;
   }): Promise<string>;
 
-  attemptTransaction(
+  checkMethod(
     contract: any,
     viewContract: any,
     methodName: string,
     params: Array<any>,
-    sendOptions: object,
-    err: Error
-  ): Promise<TransactionResult>;
+    sendOptions: {
+      gasLimit?: number | string;
+    },
+    err: Error,
+  ): Promise<void>;
+
+  execMethod(
+    contract: any,
+    methodName: string,
+    params: Array<any>,
+    sendOptions: {
+      gasLimit?: number | string;
+    }
+  ): Promise<EthersTransactionResult>;
 
   encodeAttemptTransaction(contractAbi: object[], methodName: string, params: any[]): string;
 

--- a/src/providers/CPKProvider.ts
+++ b/src/providers/CPKProvider.ts
@@ -48,6 +48,14 @@ interface CPKProvider {
     data: string;
   }): Promise<any>;
 
+  getCallRevertData(opts: {
+    from: string;
+    to: string;
+    value?: number | string;
+    data: string;
+    gasLimit?: number | string;
+  }): Promise<string>;
+
   attemptTransaction(
     contract: any,
     viewContract: any,
@@ -56,6 +64,8 @@ interface CPKProvider {
     sendOptions: object,
     err: Error
   ): Promise<TransactionResult>;
+
+  encodeAttemptTransaction(contractAbi: object[], methodName: string, params: any[]): string;
 
   attemptSafeProviderSendTx(
     tx: SafeProviderSendTransaction,

--- a/src/providers/CPKWeb3Provider.ts
+++ b/src/providers/CPKWeb3Provider.ts
@@ -136,8 +136,9 @@ class CPKWeb3Provider implements CPKProvider {
   }: {
     from: string;
     to: string;
-    value: number | string;
+    value?: number | string;
     data: string;
+    gasLimit?: number | string;
   }): Promise<string> {
     try {
       // throw with full error data if provider is Web3 1.x

--- a/src/providers/CPKWeb3Provider.ts
+++ b/src/providers/CPKWeb3Provider.ts
@@ -127,6 +127,12 @@ class CPKWeb3Provider implements CPKProvider {
     return CPKWeb3Provider.promiEventToPromise(promiEvent, sendOptions);
   }
 
+  encodeAttemptTransaction(contractAbi: object[], methodName: string, params: any[]): string {
+    const contract = this.getContract(contractAbi, zeroAddress);
+    const payload = contract.methods[methodName](...params).encodeABI();
+    return payload;
+  }
+
   async attemptSafeProviderSendTx(
     txObj: SafeProviderSendTransaction,
     sendOptions: object
@@ -182,6 +188,15 @@ class CPKWeb3Provider implements CPKProvider {
       from: ownerAccount,
       ...(options || {}),
     };
+  }
+
+  getGasPrice() {
+    return this.web3.eth.getGasPrice();
+  }
+
+  getSafeNonce(safeAddress:string) {
+    const safeContract = this.getContract(safeAbi, safeAddress);
+    return safeContract.methods.nonce().call();
   }
 }
 

--- a/src/providers/CPKWeb3Provider.ts
+++ b/src/providers/CPKWeb3Provider.ts
@@ -171,7 +171,7 @@ class CPKWeb3Provider implements CPKProvider {
     }
   }
 
-  async attemptTransaction(
+  async checkMethod(
     contract: any,
     viewContract: any,
     methodName: string,
@@ -179,9 +179,19 @@ class CPKWeb3Provider implements CPKProvider {
     sendOptions: {
       gasLimit?: number | string;
     },
-    err: Error
-  ): Promise<Web3TransactionResult> {
+    err: Error,
+  ): Promise<void> {
     if (!(await contract.methods[methodName](...params).call(sendOptions))) throw err;
+  }
+
+  async execMethod(
+    contract: any,
+    methodName: string,
+    params: Array<any>,
+    sendOptions: {
+      gasLimit?: number | string;
+    }
+  ): Promise<Web3TransactionResult> {
 
     const txObject = contract.methods[methodName](...params);
     const gasLimit = sendOptions.gasLimit || await txObject.estimateGas(sendOptions);

--- a/src/providers/CPKWeb3Provider.ts
+++ b/src/providers/CPKWeb3Provider.ts
@@ -146,12 +146,15 @@ class CPKWeb3Provider implements CPKProvider {
       // this also handles Geth/Ganache --noVMErrorsOnRPCResponse
       return await this.providerSend(
         'eth_call',
-        [{
-          from,
-          to,
-          value,
-          data,
-        }],
+        [
+          {
+            from,
+            to,
+            value,
+            data,
+          },
+          'latest',
+        ],
       );
     } catch (e) {
       let errData = e.data;

--- a/src/providers/CPKWeb3Provider.ts
+++ b/src/providers/CPKWeb3Provider.ts
@@ -122,7 +122,10 @@ class CPKWeb3Provider implements CPKProvider {
   ): Promise<Web3TransactionResult> {
     if (!(await contract.methods[methodName](...params).call(sendOptions))) throw err;
 
-    const promiEvent = contract.methods[methodName](...params).send(sendOptions);
+    const txObject = contract.methods[methodName](...params);
+    const gasLimit = sendOptions.gasLimit || await txObject.estimateGas(sendOptions)
+    const actualSendOptions = { gasLimit, ...sendOptions };
+    const promiEvent = txObject.send(actualSendOptions);
 
     return CPKWeb3Provider.promiEventToPromise(promiEvent, sendOptions);
   }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,3 @@
-const { BigNumber } = require('bignumber.js');
 const safeAbi = require('../abis/SafeAbi.json');
 const { zeroAddress } = require('./constants');
 
@@ -88,10 +87,10 @@ const estimateSafeTxGas = async (
     data: estimateData,
   });
 
-  safeTxGas = new BigNumber(estimateResponse.substring(138), 16);
+  safeTxGas = parseInt(estimateResponse.substring(138), 16);
 
   // Add 10k else we will fail in case of nested calls
-  safeTxGas = safeTxGas.toNumber() + additionalGas;
+  safeTxGas += additionalGas;
 
   const baseGasEstimate = await estimateBaseGas(
     cpkProvider,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -82,20 +82,16 @@ const estimateSafeTxGas = async (
     ],
   );
 
-  try {
-    const estimateResponse = await cpkProvider.checkSingleCall({
-      from: safeAddress,
-      to: safeAddress,
-      data: estimateData,
-    });
+  const estimateResponse = await cpkProvider.checkSingleCall({
+    from: safeAddress,
+    to: safeAddress,
+    data: estimateData,
+  });
 
-    safeTxGas = new BigNumber(estimateResponse.substring(138), 16);
+  safeTxGas = new BigNumber(estimateResponse.substring(138), 16);
 
-    // Add 10k else we will fail in case of nested calls
-    safeTxGas = safeTxGas.toNumber() + additionalGas;
-  } catch (error) {
-    console.error('Error calculating tx gas estimation', error);
-  }
+  // Add 10k else we will fail in case of nested calls
+  safeTxGas = safeTxGas.toNumber() + additionalGas;
 
   const baseGasEstimate = await estimateBaseGas(
     cpkProvider,
@@ -112,21 +108,18 @@ const estimateSafeTxGas = async (
   );
 
   for (let i = 0; i < 100; i += 1) {
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      const estimateResponse = await cpkProvider.checkSingleCall({
-        to: safeAddress,
-        from: safeAddress,
-        data: estimateData,
-        gasLimit: safeTxGas + baseGasEstimate + 32000,
-      });
+    // eslint-disable-next-line no-await-in-loop
+    const estimateResponse = await cpkProvider.checkSingleCall({
+      to: safeAddress,
+      from: safeAddress,
+      data: estimateData,
+      gasLimit: safeTxGas + baseGasEstimate + 32000,
+    });
 
-      if (estimateResponse !== '0x') {
-        break;
-      }
-    } catch (error) {
-      console.error('Error calculating tx gas estimation', error);
+    if (estimateResponse !== '0x') {
+      break;
     }
+
     safeTxGas += additionalGas;
     additionalGas *= 2;
   }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,7 +6,7 @@ const baseGasValue = (hexValue) => {
   switch (hexValue) {
   case '0x': return 0;
   case '00': return 4;
-  default: return 68;
+  default: return 16;
   }
 };
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,63 +1,8 @@
 const safeAbi = require('../abis/SafeAbi.json');
-const { zeroAddress } = require('./constants');
-
-const baseGasValue = (hexValue) => {
-  switch (hexValue) {
-  case '0x': return 0;
-  case '00': return 4;
-  default: return 16;
-  }
-};
-
-const estimateBaseGasCosts = (dataString) => {
-  // eslint-disable-next-line
-  const reducer = (accumulator, currentValue) => accumulator += baseGasValue(currentValue);
-  return dataString.match(/.{2}/g).reduce(reducer, 0);
-};
-
-const estimateBaseGas = async (
-  cpkProvider,
-  to,
-  value,
-  data,
-  operation,
-  safeTxGas,
-  gasToken,
-  refundReceiver,
-  signatureCount,
-  nonce,
-  gasPrice,
-) => {
-  // (array count (3 -> r, s, v) + ecrecover costs) * signature count
-  const signatureCost = signatureCount * (68 + 2176 + 2176 + 6000);
-
-  const payload = cpkProvider.encodeAttemptTransaction(
-    safeAbi,
-    'execTransaction',
-    [
-      to,
-      value,
-      data,
-      operation,
-      safeTxGas,
-      0,
-      gasPrice,
-      gasToken,
-      refundReceiver,
-      '0x',
-    ],
-  );
-
-  let baseGasEstimate = estimateBaseGasCosts(payload) + signatureCost + (nonce > 0 ? 5000 : 20000);
-  baseGasEstimate += 1500; // 1500 -> hash generation costs
-  baseGasEstimate += 1000; // 1000 -> Event emission
-  return baseGasEstimate + 32000; // Add aditional gas costs (e.g. base tx costs, transfer costs)
-};
 
 const estimateSafeTxGas = async (
   cpkProvider,
   safeAddress,
-  signatureCount,
   data,
   to,
   value,
@@ -65,11 +10,7 @@ const estimateSafeTxGas = async (
 ) => {
   let safeTxGas;
   let additionalGas = 10000;
-  const txGasToken = zeroAddress;
-  const refundReceiver = zeroAddress;
 
-  const gasPrice = await cpkProvider.getGasPrice();
-  const nonce = await cpkProvider.getSafeNonce(safeAddress);
   const estimateData = cpkProvider.encodeAttemptTransaction(
     safeAbi,
     'requiredTxGas',
@@ -92,19 +33,7 @@ const estimateSafeTxGas = async (
   // Add 10k else we will fail in case of nested calls
   safeTxGas += additionalGas;
 
-  const baseGasEstimate = await estimateBaseGas(
-    cpkProvider,
-    to,
-    value,
-    data,
-    operation,
-    safeTxGas,
-    txGasToken,
-    refundReceiver,
-    signatureCount,
-    nonce,
-    gasPrice,
-  );
+  const baseGasEstimate = 6000 + 1500 + 1000 + 32000;
 
   for (let i = 0; i < 100; i += 1) {
     // eslint-disable-next-line no-await-in-loop
@@ -112,7 +41,7 @@ const estimateSafeTxGas = async (
       to: safeAddress,
       from: safeAddress,
       data: estimateData,
-      gasLimit: safeTxGas + baseGasEstimate + 32000,
+      gasLimit: safeTxGas + baseGasEstimate,
     });
 
     if (estimateResponse !== '0x') {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,40 @@
+const { BigNumber } = require('bignumber.js');
+const safeAbi = require('../abis/SafeAbi.json');
+
+const estimateSafeTxGas = async (
+  cpkProvider,
+  safeAddress,
+  data,
+  to,
+  value,
+  operation,
+) => {
+  try {
+    const safe = cpkProvider.getContract(safeAbi, safeAddress);
+
+    let estimateData;
+    if (cpkProvider.web3) {
+      estimateData = safe.methods.requiredTxGas(to, value, data, operation).encodeABI();
+    } else if (cpkProvider.ethers && cpkProvider.signer) {
+      estimateData = await safe.requiredTxGas(to, value, data, operation);
+    }
+
+    const estimateResponse = await cpkProvider.checkSingleCall({
+      from: safeAddress,
+      to: safeAddress,
+      data: estimateData,
+    });
+
+    const txGasEstimate = new BigNumber(estimateResponse.substring(138), 16);
+
+    // Add 10k else we will fail in case of nested calls
+    const safeTxGas = txGasEstimate.toNumber() + 10000;
+
+    return safeTxGas;
+  } catch (error) {
+    console.error('Error calculating tx gas estimation', error);
+    return 0;
+  }
+};
+
+module.exports = { estimateSafeTxGas };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,40 +1,136 @@
 const { BigNumber } = require('bignumber.js');
 const safeAbi = require('../abis/SafeAbi.json');
+const { zeroAddress } = require('./constants');
+
+const baseGasValue = (hexValue) => {
+  switch (hexValue) {
+  case '0x': return 0;
+  case '00': return 4;
+  default: return 68;
+  }
+};
+
+const estimateBaseGasCosts = (dataString) => {
+  // eslint-disable-next-line
+  const reducer = (accumulator, currentValue) => accumulator += baseGasValue(currentValue);
+  return dataString.match(/.{2}/g).reduce(reducer, 0);
+};
+
+const estimateBaseGas = async (
+  cpkProvider,
+  to,
+  value,
+  data,
+  operation,
+  txGasEstimate,
+  gasToken,
+  refundReceiver,
+  signatureCount,
+  nonce,
+  gasPrice,
+) => {
+  // (array count (3 -> r, s, v) + ecrecover costs) * signature count
+  const signatureCost = signatureCount * (68 + 2176 + 2176 + 6000);
+
+  const payload = cpkProvider.encodeAttemptTransaction(
+    safeAbi,
+    'execTransaction',
+    [
+      to,
+      value,
+      data,
+      operation,
+      txGasEstimate,
+      0,
+      gasPrice,
+      gasToken,
+      refundReceiver,
+      '0x',
+    ],
+  );
+
+  let baseGasEstimate = estimateBaseGasCosts(payload) + signatureCost + (nonce > 0 ? 5000 : 20000);
+  baseGasEstimate += 1500; // 1500 -> hash generation costs
+  baseGasEstimate += 1000; // 1000 -> Event emission
+  return baseGasEstimate + 32000; // Add aditional gas costs (e.g. base tx costs, transfer costs)
+};
 
 const estimateSafeTxGas = async (
   cpkProvider,
   safeAddress,
+  signatureCount,
   data,
   to,
   value,
   operation,
 ) => {
+  let txGasEstimate;
+  let additionalGas = 10000;
+  const txGasToken = zeroAddress;
+  const refundReceiver = zeroAddress;
+  
+  const gasPrice = await cpkProvider.getGasPrice();
+  const nonce = await cpkProvider.getSafeNonce(safeAddress);
+  const estimateData = cpkProvider.encodeAttemptTransaction(
+    safeAbi,
+    'requiredTxGas',
+    [
+      to,
+      value,
+      data,
+      operation,
+    ],
+  );
+
   try {
-    const safe = cpkProvider.getContract(safeAbi, safeAddress);
-
-    let estimateData;
-    if (cpkProvider.web3) {
-      estimateData = safe.methods.requiredTxGas(to, value, data, operation).encodeABI();
-    } else if (cpkProvider.ethers && cpkProvider.signer) {
-      estimateData = await safe.requiredTxGas(to, value, data, operation);
-    }
-
     const estimateResponse = await cpkProvider.checkSingleCall({
       from: safeAddress,
       to: safeAddress,
       data: estimateData,
     });
-
-    const txGasEstimate = new BigNumber(estimateResponse.substring(138), 16);
+    txGasEstimate = new BigNumber(estimateResponse.substring(138), 16);
 
     // Add 10k else we will fail in case of nested calls
-    const safeTxGas = txGasEstimate.toNumber() + 10000;
-
-    return safeTxGas;
+    txGasEstimate = txGasEstimate.toNumber() + additionalGas;
   } catch (error) {
     console.error('Error calculating tx gas estimation', error);
-    return 0;
   }
+
+  const baseGasEstimate = await estimateBaseGas(
+    cpkProvider,
+    to,
+    value,
+    data,
+    operation,
+    txGasEstimate,
+    txGasToken,
+    refundReceiver,
+    signatureCount,
+    nonce,
+    gasPrice,
+  );
+
+  for (let i = 0; i < 100; i += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const estimateResponse = await cpkProvider.checkSingleCall({
+        to: safeAddress,
+        from: safeAddress,
+        data: estimateData,
+        gasLimit: txGasEstimate + baseGasEstimate + 32000,
+      });
+
+      if (estimateResponse !== '0x') {
+        break;
+      }
+    } catch (error) {
+      console.error('Error calculating tx gas estimation', error);
+    }
+    txGasEstimate += additionalGas;
+    additionalGas *= 2;
+  }
+
+  return { safeTxGas: txGasEstimate, baseGas: baseGasEstimate };
 };
 
 module.exports = { estimateSafeTxGas };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -22,7 +22,7 @@ const estimateSafeTxGas = async (
     ],
   );
 
-  const estimateResponse = await cpkProvider.checkSingleCall({
+  const estimateResponse = await cpkProvider.getCallRevertData({
     from: safeAddress,
     to: safeAddress,
     data: estimateData,
@@ -37,7 +37,7 @@ const estimateSafeTxGas = async (
 
   for (let i = 0; i < 100; i += 1) {
     // eslint-disable-next-line no-await-in-loop
-    const estimateResponse = await cpkProvider.checkSingleCall({
+    const estimateResponse = await cpkProvider.getCallRevertData({
       to: safeAddress,
       from: safeAddress,
       data: estimateData,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,13 +1,18 @@
-const safeAbi = require('../abis/SafeAbi.json');
+import safeAbi from '../abis/SafeAbi.json';
+import CPKProvider from '../providers/CPKProvider';
+import { OperationType } from './constants';
 
 const estimateSafeTxGas = async (
-  cpkProvider,
-  safeAddress,
-  data,
-  to,
-  value,
-  operation,
-) => {
+  cpkProvider: CPKProvider,
+  safeAddress: string,
+  data: string,
+  to: string,
+  value: number | string,
+  operation: OperationType,
+): Promise<{
+  safeTxGas: number;
+  baseGas: number;
+}> => {
   let safeTxGas;
   let additionalGas = 10000;
 

--- a/test/contract-proxy-kit.js
+++ b/test/contract-proxy-kit.js
@@ -15,6 +15,10 @@ const DefaultCallbackHandler = artifacts.require('DefaultCallbackHandler');
 const ProxyFactory = artifacts.require('ProxyFactory');
 
 contract('CPK', ([defaultAccount, safeOwner]) => {
+  if (safeOwner == null) {
+    safeOwner = defaultAccount;
+  }
+
   const gnosisSafeProviderBox = [];
 
   before('emulate Gnosis Safe WalletConnect provider', async () => {

--- a/test/ethers/shouldWorkWithEthers.js
+++ b/test/ethers/shouldWorkWithEthers.js
@@ -107,7 +107,7 @@ function shouldWorkWithEthers(ethers, defaultAccount, safeOwner, gnosisSafeProvi
           const idPrecompile = `0x${'0'.repeat(39)}4`;
           await cpk.execTransactions([{
             to: idPrecompile,
-          }], { gasLimit: defaultGasLimit });
+          }]);
         });
 
         shouldSupportDifferentTransactions({

--- a/test/ethers/shouldWorkWithEthers.js
+++ b/test/ethers/shouldWorkWithEthers.js
@@ -1,7 +1,7 @@
 import CPK from '../../src';
 import CPKEthersProvider from '../../src/providers/CPKEthersProvider';
 import shouldSupportDifferentTransactions from '../transactions/shouldSupportDifferentTransactions';
-import { defaultGasLimit, toConfirmationPromise } from '../utils';
+import { toConfirmationPromise } from '../utils';
 
 const GnosisSafe = artifacts.require('GnosisSafe');
 const MultiSend = artifacts.require('MultiSend');

--- a/test/transactions/shouldSupportDifferentTransactions.js
+++ b/test/transactions/shouldSupportDifferentTransactions.js
@@ -168,7 +168,9 @@ function shouldSupportDifferentTransactions({
       fromWei(await erc20.balanceOf(conditionalTokens.address)).should.equal(1);
     });
 
-    it('by default errors without transacting when single transaction would fail', async () => {
+    (
+      ownerIsRecognizedContract ? it.skip : it
+    )('by default errors without transacting when single transaction would fail', async () => {
       (await multiStep.lastStepFinished(cpk.address)).toNumber().should.equal(0);
       const startingTransactionCount = await getTransactionCount(proxyOwner);
 

--- a/test/transactions/shouldSupportDifferentTransactions.js
+++ b/test/transactions/shouldSupportDifferentTransactions.js
@@ -74,7 +74,7 @@ function shouldSupportDifferentTransactions({
       await cpk.execTransactions([{
         to: multiStep.address,
         data: multiStep.contract.methods.doStep(1).encodeABI(),
-      }], { gasLimit: defaultGasLimit });
+      }]);
       (await multiStep.lastStepFinished(cpk.address)).toNumber().should.equal(1);
     });
 
@@ -89,7 +89,7 @@ function shouldSupportDifferentTransactions({
           to: multiStep.address,
           data: multiStep.contract.methods.doStep(2).encodeABI(),
         },
-      ], { gasLimit: defaultGasLimit });
+      ]);
       (await multiStep.lastStepFinished(cpk.address)).toNumber().should.equal(2);
     });
 
@@ -113,7 +113,7 @@ function shouldSupportDifferentTransactions({
           to: multiStep.address,
           data: multiStep.contract.methods.doERC20Step(2, erc20.address).encodeABI(),
         },
-      ], { gasLimit: defaultGasLimit });
+      ]);
 
       (await multiStep.lastStepFinished(cpk.address)).toNumber().should.equal(2);
 
@@ -157,7 +157,7 @@ function shouldSupportDifferentTransactions({
             `${1e18}`,
           ).encodeABI(),
         },
-      ], { gasLimit: defaultGasLimit });
+      ]);
 
       if (cpk.address === proxyOwner) {
         fromWei(await erc20.balanceOf(cpk.address)).should.equal(99);
@@ -175,7 +175,7 @@ function shouldSupportDifferentTransactions({
       await cpk.execTransactions([{
         to: multiStep.address,
         data: multiStep.contract.methods.doStep(2).encodeABI(),
-      }], { gasLimit: defaultGasLimit }).should.be.rejectedWith(/must do the next step/);
+      }]).should.be.rejectedWith(/must do the next step/);
 
       (await multiStep.lastStepFinished(cpk.address)).toNumber().should.equal(0);
       await getTransactionCount(proxyOwner)
@@ -196,7 +196,7 @@ function shouldSupportDifferentTransactions({
           to: multiStep.address,
           data: multiStep.contract.methods.doStep(3).encodeABI(),
         },
-      ], { gasLimit: defaultGasLimit }).should.be.rejectedWith(/(proxy creation and )?transaction execution expected to fail/);
+      ]).should.be.rejectedWith(/(proxy creation and )?transaction execution expected to fail/);
 
       (await multiStep.lastStepFinished(cpk.address)).toNumber().should.equal(0);
       await getTransactionCount(proxyOwner)
@@ -207,7 +207,7 @@ function shouldSupportDifferentTransactions({
       checkTxObj(await cpk.execTransactions([{
         to: multiStep.address,
         data: multiStep.contract.methods.doStep(1).encodeABI(),
-      }], { gasLimit: defaultGasLimit }));
+      }]));
     });
 
     it('can execute a single transaction with a specific gas price', async () => {
@@ -221,7 +221,7 @@ function shouldSupportDifferentTransactions({
           to: multiStep.address,
           data: multiStep.contract.methods.doStep(1).encodeABI(),
         }],
-        { gasPrice, gasLimit: defaultGasLimit },
+        { gasPrice },
       );
       const gasUsed = await getGasUsed(txObj);
 
@@ -249,7 +249,7 @@ function shouldSupportDifferentTransactions({
             data: multiStep.contract.methods.doStep(2).encodeABI(),
           },
         ],
-        { gasPrice, gasLimit: defaultGasLimit },
+        { gasPrice },
       );
       const gasUsed = await getGasUsed(txObj);
 

--- a/test/transactions/shouldSupportDifferentTransactions.js
+++ b/test/transactions/shouldSupportDifferentTransactions.js
@@ -63,7 +63,7 @@ function shouldSupportDifferentTransactions({
         from: proxyOwner,
         to: erc20.address,
         value: 0,
-        gasLimit: '0x5b8d80',
+        gas: '0x5b8d80',
         data: erc20.contract.methods.approve(cpk.address, `${1e20}`).encodeABI(),
       });
     });

--- a/test/transactions/shouldSupportDifferentTransactions.js
+++ b/test/transactions/shouldSupportDifferentTransactions.js
@@ -175,7 +175,7 @@ function shouldSupportDifferentTransactions({
       await cpk.execTransactions([{
         to: multiStep.address,
         data: multiStep.contract.methods.doStep(2).encodeABI(),
-      }]).should.be.rejectedWith(/must do the next step/);
+      }]).should.be.rejectedWith(/must do the next step|(proxy creation and )?transaction execution expected to fail/);
 
       (await multiStep.lastStepFinished(cpk.address)).toNumber().should.equal(0);
       await getTransactionCount(proxyOwner)
@@ -196,7 +196,7 @@ function shouldSupportDifferentTransactions({
           to: multiStep.address,
           data: multiStep.contract.methods.doStep(3).encodeABI(),
         },
-      ]).should.be.rejectedWith(/(proxy creation and )?transaction execution expected to fail/);
+      ]).should.be.rejectedWith(/(proxy creation and )?batch transaction execution expected to fail/);
 
       (await multiStep.lastStepFinished(cpk.address)).toNumber().should.equal(0);
       await getTransactionCount(proxyOwner)

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,11 +1,8 @@
-const defaultGasLimit = '0x100000';
-
 const toConfirmationPromise = (promiEvent) => new Promise(
   (resolve, reject) => promiEvent.on('confirmation',
     (confirmationNumber, receipt) => resolve(receipt)).catch(reject),
 );
 
 module.exports = {
-  defaultGasLimit,
   toConfirmationPromise,
 };

--- a/test/web3/shouldWorkWithWeb3.js
+++ b/test/web3/shouldWorkWithWeb3.js
@@ -117,7 +117,7 @@ function shouldWorkWithWeb3(Web3, defaultAccount, safeOwner, gnosisSafeProviderB
               from: defaultAccount,
               to: newAccount.address,
               value: `${2e18}`,
-              gasLimit: '0x5b8d80',
+              gas: '0x5b8d80',
             });
 
             const cpkProvider = new CPKWeb3Provider({ web3: ueb3 });

--- a/test/web3/shouldWorkWithWeb3.js
+++ b/test/web3/shouldWorkWithWeb3.js
@@ -98,7 +98,7 @@ function shouldWorkWithWeb3(Web3, defaultAccount, safeOwner, gnosisSafeProviderB
           const idPrecompile = `0x${'0'.repeat(39)}4`;
           await cpk.execTransactions([{
             to: idPrecompile,
-          }], { gasLimit: defaultGasLimit });
+          }]);
         });
 
         shouldSupportDifferentTransactions({

--- a/test/web3/shouldWorkWithWeb3.js
+++ b/test/web3/shouldWorkWithWeb3.js
@@ -1,7 +1,7 @@
 import CPK from '../../src';
 import CPKWeb3Provider from '../../src/providers/CPKWeb3Provider';
 import shouldSupportDifferentTransactions from '../transactions/shouldSupportDifferentTransactions';
-import { defaultGasLimit, toConfirmationPromise } from '../utils';
+import { toConfirmationPromise } from '../utils';
 
 const GnosisSafe = artifacts.require('GnosisSafe');
 const MultiSend = artifacts.require('MultiSend');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1393,6 +1393,11 @@ camelcase@^3.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
   integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
 
+camelcase@^5.0.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
 caniuse-lite@^1.0.30000844:
   version "1.0.30001032"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001032.tgz#b8d224914e2cd7f507085583d4e38144c652bce4"
@@ -1506,6 +1511,15 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+cliui@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  dependencies:
+    string-width "^3.1.0"
+    strip-ansi "^5.2.0"
+    wrap-ansi "^5.1.0"
+
 clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
@@ -1595,6 +1609,11 @@ color-support@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
+
+colors@^1.1.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -1749,7 +1768,7 @@ cross-fetch@^2.1.0, cross-fetch@^2.1.1:
     node-fetch "2.1.2"
     whatwg-fetch "2.0.4"
 
-cross-spawn@^6.0.5:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -1818,7 +1837,7 @@ debug@^4.0.1, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.1.1:
+decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -2535,6 +2554,19 @@ ethereumjs-tx@^2.1.1:
     ethereumjs-common "^1.5.0"
     ethereumjs-util "^6.0.0"
 
+ethereumjs-util@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz#e9c51e5549e8ebd757a339cc00f5380507e799c8"
+  integrity sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==
+  dependencies:
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    ethjs-util "0.1.6"
+    keccak "^1.0.2"
+    rlp "^2.0.0"
+    safe-buffer "^5.1.1"
+    secp256k1 "^3.0.1"
+
 ethereumjs-util@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz#3e9428b317eebda3d7260d854fddda954b1f1bc6"
@@ -2706,6 +2738,19 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
+
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 expand-brackets@^2.1.4:
   version "2.1.4"
@@ -2934,6 +2979,20 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
+find-up@^2.0.0, find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
+  dependencies:
+    locate-path "^2.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
 findup-sync@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
@@ -3105,10 +3164,24 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+ganache-cli@^6.4.2:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.9.1.tgz#1e13eee098fb9f19b031a191ec3f62ae926ea8b3"
+  integrity sha512-VPBumkNUZzXDRQwVOby5YyQpd5t1clkr06xMgB28lZdEIn5ht1GMwUskOTFOAxdkQ4J12IWP0gdeacVRGowqbA==
+  dependencies:
+    ethereumjs-util "6.1.0"
+    source-map-support "0.5.12"
+    yargs "13.2.4"
+
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
+
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-stream@^2.2.0:
   version "2.3.1"
@@ -3123,7 +3196,7 @@ get-stream@^3.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
-get-stream@^4.1.0:
+get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
   integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
@@ -3658,6 +3731,11 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
+invert-kv@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
+  integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -4190,6 +4268,13 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+lcid@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
+  integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
+  dependencies:
+    invert-kv "^2.0.0"
+
 lead@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lead/-/lead-1.0.0.tgz#6f14f99a37be3a9dd784f5495690e5903466ee42"
@@ -4280,6 +4365,32 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  integrity sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
@@ -4326,6 +4437,13 @@ make-iterator@^1.0.0:
   dependencies:
     kind-of "^6.0.2"
 
+map-age-cleaner@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+  dependencies:
+    p-defer "^1.0.0"
+
 map-cache@^0.2.0, map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
@@ -4361,6 +4479,15 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
+mem@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
+  integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
+  dependencies:
+    map-age-cleaner "^0.1.1"
+    mimic-fn "^2.0.0"
+    p-is-promise "^2.0.0"
 
 memdown@^1.0.0:
   version "1.4.1"
@@ -4447,7 +4574,7 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mimic-fn@^2.1.0:
+mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
@@ -4679,6 +4806,13 @@ now-and-later@^2.0.0:
   dependencies:
     once "^1.3.2"
 
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
+  dependencies:
+    path-key "^2.0.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -4850,6 +4984,15 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
+os-locale@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
+  integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
+  dependencies:
+    execa "^1.0.0"
+    lcid "^2.0.0"
+    mem "^4.0.0"
+
 os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -4870,12 +5013,55 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
+p-is-promise@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
+  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
+
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
+  dependencies:
+    p-try "^1.0.0"
+
+p-limit@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+  dependencies:
+    p-try "^2.0.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
+  dependencies:
+    p-limit "^1.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
+
 p-timeout@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-1.2.1.tgz#5eb3b353b7fce99f101a1038880bb054ebbea386"
   integrity sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=
   dependencies:
     p-finally "^1.0.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -4954,7 +5140,7 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-key@^2.0.1:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
@@ -5446,6 +5632,11 @@ require-main-filename@^1.0.1:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
 
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -5545,6 +5736,14 @@ run-async@^2.4.0:
   integrity sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==
   dependencies:
     is-promise "^2.1.0"
+
+run-with-testrpc@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/run-with-testrpc/-/run-with-testrpc-0.3.1.tgz#93dcaab062ece14fb0c02d28def5f05e4bd8e136"
+  integrity sha512-+G9L7oMhLNXStmXGSjWtWxu7QVTJROJq3P1vruH01FaRtDiKIuvgqs9aZ3eJoTkfjg6UoOPxg/kwgYZlwKIvoQ==
+  dependencies:
+    colors "^1.1.2"
+    ganache-cli "^6.4.2"
 
 rustbn.js@~0.2.0:
   version "0.2.0"
@@ -5841,6 +6040,11 @@ should@^13.2.3:
     should-type-adaptors "^1.0.1"
     should-util "^1.0.0"
 
+signal-exit@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
+  integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
 signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -5928,6 +6132,14 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-support@0.5.12:
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
+  integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
 source-map-support@^0.4.15:
   version "0.4.18"
@@ -6059,7 +6271,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^3.0.0:
+string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
   integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
@@ -6121,7 +6333,7 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
-strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -6148,6 +6360,11 @@ strip-dirs@^2.0.0:
   integrity sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==
   dependencies:
     is-natural-number "^4.0.1"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+  integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
 strip-hex-prefix@1.0.0:
   version "1.0.0"
@@ -7545,6 +7762,11 @@ which-module@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
   integrity sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=
 
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
 which@^1.2.14, which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -7564,6 +7786,15 @@ wrap-ansi@^2.0.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
 
 wrappy@1:
   version "1.0.2"
@@ -7657,6 +7888,11 @@ y18n@^3.2.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
   integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
 
+y18n@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
 yaeti@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
@@ -7667,12 +7903,37 @@ yallist@^3.0.0, yallist@^3.0.3:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
+yargs-parser@^13.1.0:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
   integrity sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=
   dependencies:
     camelcase "^3.0.0"
+
+yargs@13.2.4:
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.2.4.tgz#0b562b794016eb9651b98bd37acf364aa5d6dc83"
+  integrity sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==
+  dependencies:
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    os-locale "^3.1.0"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.0"
 
 yargs@^7.1.0:
   version "7.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,11 +1083,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bignumber.js@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
-  integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
-
 "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2":
   version "2.0.7"
   resolved "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
@@ -7747,7 +7742,6 @@ web3@^0.18.2:
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
-    gulp "^4.0.2"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,6 +1083,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bignumber.js@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
+  integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
+
 "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2":
   version "2.0.7"
   resolved "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"


### PR DESCRIPTION
Edit notes:

Discovered that `eth_call` is totally unspecified for error cases, which is why the `--noVMErrorsOnRPCResponse` got set on Ganache. Here's a summary of what is happening:

- Regular Ganache runs return a VM error with `eth_call`, and Ganache will attempt to decode the revert reason data as a UTF-8 string to send as part of the error. There is raw "return" data, <s>but I think it is actually just the original `calldata` echoed back</s> and it's an ABI-encoded Error.
- Ganache using `--noVMErrorsOnRPCResponse` and Geth will return the data supplied to `revert` call _as_ the response. There's no distinguishing this from a regular return. Our use case depends on this behavior, as buggy as it feels to me.
- Parity/OpenEthereum will return a "VM execution error." Similar to the regular Ganache, there's raw "return" data <s>which is actually just the `calldata` echoed back, so there isn't a way to use Parity to do a gas estimate through the `requiredTxGas` method</s>.

Edit 2: Found that it's not the `calldata` echoed back, but actually ABI-encoded `Error(string)` data: https://solidity.readthedocs.io/en/latest/control-structures.html#revert

This also explains the `.substring(138)` that I didn't understand.

In any case, it is a matter of getting that data now.

Edit 3: works with OpenEthereum now. Tested with the following:

```sh
parity --config dev --unlock 0x00a329c0648769a73afac7f9381e08fb43dbea72 --password <(echo '')
```