### PR TITLE
Gsn support

### DIFF
--- a/contracts/CPKFactory.sol
+++ b/contracts/CPKFactory.sol
@@ -3,9 +3,18 @@ pragma solidity >=0.5.0 <0.7.0;
 import { Enum } from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import { Proxy } from "@gnosis.pm/safe-contracts/contracts/proxies/Proxy.sol";
 import { GnosisSafe } from "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
+import "./GsnModule.sol";
 
-contract CPKFactory {
+contract CPKFactory is BaseRelayRecipient {
     event ProxyCreation(Proxy proxy);
+
+    GsnModule public gsnModule = new GsnModule();
+
+    function setForwarder(address forwarder) public {
+        require(trustedForwarder==address(0), "Forwrader already set");
+        gsnModule.setForwarder(forwarder);
+        trustedForwarder=forwarder;
+    }
 
     function proxyCreationCode() external pure returns (bytes memory) {
         return type(Proxy).creationCode;
@@ -25,7 +34,7 @@ contract CPKFactory {
     {
         GnosisSafe proxy;
         bytes memory deploymentData = abi.encodePacked(type(Proxy).creationCode, abi.encode(masterCopy));
-        bytes32 salt = keccak256(abi.encode(msg.sender, saltNonce));
+        bytes32 salt = keccak256(abi.encode(_msgSender(), saltNonce));
         // solium-disable-next-line security/no-inline-assembly
         assembly {
             proxy := create2(0x0, add(0x20, deploymentData), mload(deploymentData), salt)
@@ -35,7 +44,11 @@ contract CPKFactory {
         {
             address[] memory tmp = new address[](1);
             tmp[0] = address(this);
-            proxy.setup(tmp, 1, address(0), "", fallbackHandler, address(0), 0, address(0));
+            address _fallbackHandler = fallbackHandler;
+            proxy.setup(tmp, 1,
+                address(gsnModule), //address for delegateCall
+                abi.encodeWithSignature("setup(address)", gsnModule),
+                _fallbackHandler, address(0), 0, address(0));
         }
 
         execTransactionSuccess = proxy.execTransaction(to, value, data, operation, 0, 0, 0, address(0), address(0),
@@ -43,7 +56,7 @@ contract CPKFactory {
 
         proxy.execTransaction(
             address(proxy), 0,
-            abi.encodeWithSignature("swapOwner(address,address,address)", address(1), address(this), msg.sender),
+            abi.encodeWithSignature("swapOwner(address,address,address)", address(1), address(this), _msgSender()),
             Enum.Operation.Call,
             0, 0, 0, address(0), address(0),
             abi.encodePacked(uint(address(this)), uint(0), uint8(1))

--- a/contracts/GsnModule.sol
+++ b/contracts/GsnModule.sol
@@ -1,0 +1,28 @@
+pragma solidity >=0.5.0 <0.7.0;
+
+import { GnosisSafe } from "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
+import { Module } from "@gnosis.pm/safe-contracts/contracts/base/Module.sol";
+import { Enum } from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
+import { BaseRelayRecipient } from "./gsn/BaseRelayRecipient.sol";
+
+contract GsnModule is Module, BaseRelayRecipient {
+
+    function setForwarder(address forwarder) public {
+        require(trustedForwarder==address(0), "Forwrader already set");
+        trustedForwarder=forwarder;
+    }
+
+
+    function execCall(GnosisSafe proxy, address to, bytes calldata data,Enum.Operation operation) external {
+        require( proxy.isOwner(_msgSender()), "execCall: not owner");
+        proxy.execTransactionFromModule(to, 0, data, operation);
+    }
+
+    //called as delegatecall during setup, to add this GsnModule as a module.
+    // since its a delegateCall, "this" is the GnosisSafe itself, and the module (real this) is a parameter...
+    function setup(GsnModule gsnModule) external {
+
+        GnosisSafe(address(uint160(address(this)))).enableModule(gsnModule);
+    }
+
+}

--- a/contracts/gsn/BaseRelayRecipient.sol
+++ b/contracts/gsn/BaseRelayRecipient.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier:MIT
+pragma solidity ^0.5;
+
+import "@0x/contracts-utils/contracts/src/LibBytes.sol";
+
+import "./interfaces/IRelayRecipient.sol";
+import "./interfaces/IKnowForwarderAddress.sol";
+/**
+ * A base contract to be inherited by any contract that want to receive relayed transactions
+ * A subclass must use "_msgSender()" instead of "msg.sender"
+ */
+contract BaseRelayRecipient is IRelayRecipient, IKnowForwarderAddress {
+
+    /// the TrustedForwarder singleton we accept calls from.
+    // we trust it to verify the caller's signature, and pass the caller's address as last 20 bytes
+    address internal trustedForwarder;
+
+    function getTrustedForwarder() public view returns(address) {
+        return trustedForwarder;
+    }
+
+    /*
+     * require a function to be called through GSN only
+     */
+    modifier trustedForwarderOnly() {
+        require(msg.sender == address(trustedForwarder), "Function can only be called through trustedForwarder");
+        _;
+    }
+
+    function isTrustedForwarder(address forwarder) public view returns(bool) {
+        return forwarder == trustedForwarder;
+    }
+
+    /**
+     * return the sender of this call.
+     * if the call came through our trusted forwarder, return the original sender.
+     * otherwise, return `msg.sender`.
+     * should be used in the contract anywhere instead of msg.sender
+     */
+    function _msgSender() internal view returns (address payable) {
+        if (msg.data.length >= 24 && isTrustedForwarder(msg.sender)) {
+            // At this point we know that the sender is a trusted forwarder,
+            // so we trust that the last bytes of msg.data are the verified sender address.
+            // extract sender address from the end of msg.data
+            return address(uint160(LibBytes.readAddress(msg.data, msg.data.length - 20)));
+        }
+        return msg.sender;
+    }
+}

--- a/contracts/gsn/interfaces/IKnowForwarderAddress.sol
+++ b/contracts/gsn/interfaces/IKnowForwarderAddress.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier:MIT
+pragma solidity ^0.5;
+
+interface IKnowForwarderAddress {
+
+    /**
+     * return the forwarder we trust to forward relayed transactions to us.
+     * the forwarder is required to verify the sender's signature, and verify
+     * the call is not a replay.
+     */
+    function getTrustedForwarder() external view returns(address);
+}

--- a/contracts/gsn/interfaces/IRelayRecipient.sol
+++ b/contracts/gsn/interfaces/IRelayRecipient.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier:MIT
+pragma solidity ^0.5;
+
+/**
+ * a contract must implement this interface in order to support relayed transaction.
+ * It is better to inherit the BaseRelayRecipient as its implementation.
+ */
+contract IRelayRecipient {
+
+    /**
+     * return if the forwarder is trusted to forward relayed transactions to us.
+     * the forwarder is required to verify the sender's signature, and verify
+     * the call is not a replay.
+     */
+    function isTrustedForwarder(address forwarder) public view returns(bool);
+
+    /**
+     * return the sender of this call.
+     * if the call came through our trusted forwarder, then the real sender is appended as the last 20 bytes
+     * of the msg.data.
+     * otherwise, return `msg.sender`
+     * should be used in the contract anywhere instead of msg.sender
+     */
+    function _msgSender() internal view returns (address payable);
+
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Enable batched transactions and contract account interactions using a unique deterministic Gnosis Safe.",
   "main": "src/index.js",
   "scripts": {
-    "test": "truffle test"
+    "test": "truffle test --bail"
   },
   "repository": {
     "type": "git",

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -19,7 +19,7 @@ const networks = Object.assign(...[
     ),
   },
 })), {
-  private: {
+  development: {
     host: 'localhost',
     port: 8545,
     network_id: '*',


### PR DESCRIPTION
This is a POC for making CPK GSN-Aware.
CPKFactory is GSN-aware (can be called from gasless account)
generates a GnosisSafe proxy, with GsnModule to accept GSN gasless requests.

NOTE:
- the test was modified so that the "proxyOwner" is not a real account, so must use GSN to make requests.
- some tests (under "with mock contracts") use "proxyOwner" just as an account with eth (and tokens) and not as a proxy owner. Instead of renaming it, I set it to a "normal" eth-based account (which is not the proxy owner)