### PR TITLE
Add Safe modules configuration

### DIFF
--- a/contracts/Deps.sol
+++ b/contracts/Deps.sol
@@ -5,5 +5,6 @@ import { MultiSend } from "@gnosis.pm/safe-contracts/contracts/libraries/MultiSe
 import { GnosisSafe } from "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
 import { DefaultCallbackHandler } from "@gnosis.pm/safe-contracts/contracts/handler/DefaultCallbackHandler.sol";
 import { DailyLimitModule } from "@gnosis.pm/safe-contracts/contracts/modules/DailyLimitModule.sol";
+import { SocialRecoveryModule } from "@gnosis.pm/safe-contracts/contracts/modules/SocialRecoveryModule.sol";
 import { ConditionalTokens } from "@gnosis.pm/conditional-tokens-contracts/contracts/ConditionalTokens.sol";
 import { ERC20Mintable } from "openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";

--- a/contracts/Deps.sol
+++ b/contracts/Deps.sol
@@ -4,5 +4,6 @@ import { ProxyFactory } from "@gnosis.pm/safe-contracts/contracts/proxies/ProxyF
 import { MultiSend } from "@gnosis.pm/safe-contracts/contracts/libraries/MultiSend.sol";
 import { GnosisSafe } from "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
 import { DefaultCallbackHandler } from "@gnosis.pm/safe-contracts/contracts/handler/DefaultCallbackHandler.sol";
+import { DailyLimitModule } from "@gnosis.pm/safe-contracts/contracts/modules/DailyLimitModule.sol";
 import { ConditionalTokens } from "@gnosis.pm/conditional-tokens-contracts/contracts/ConditionalTokens.sol";
 import { ERC20Mintable } from "openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";

--- a/contracts/Deps.sol
+++ b/contracts/Deps.sol
@@ -5,6 +5,5 @@ import { MultiSend } from "@gnosis.pm/safe-contracts/contracts/libraries/MultiSe
 import { GnosisSafe } from "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
 import { DefaultCallbackHandler } from "@gnosis.pm/safe-contracts/contracts/handler/DefaultCallbackHandler.sol";
 import { DailyLimitModule } from "@gnosis.pm/safe-contracts/contracts/modules/DailyLimitModule.sol";
-import { SocialRecoveryModule } from "@gnosis.pm/safe-contracts/contracts/modules/SocialRecoveryModule.sol";
 import { ConditionalTokens } from "@gnosis.pm/conditional-tokens-contracts/contracts/ConditionalTokens.sol";
 import { ERC20Mintable } from "openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";

--- a/migrations-ts/1-deploy-contracts.ts
+++ b/migrations-ts/1-deploy-contracts.ts
@@ -13,6 +13,7 @@ module.exports = function(deployer: Truffle.Deployer, network: string) {
       'DefaultCallbackHandler',
       'Multistep',
       'DailyLimitModule',
+      'SocialRecoveryModule',
       'ERC20Mintable',
       'ConditionalTokens'
     ].forEach(deploy);

--- a/migrations-ts/1-deploy-contracts.ts
+++ b/migrations-ts/1-deploy-contracts.ts
@@ -12,6 +12,7 @@ module.exports = function(deployer: Truffle.Deployer, network: string) {
       'MultiSend',
       'DefaultCallbackHandler',
       'Multistep',
+      'DailyLimitModule',
       'ERC20Mintable',
       'ConditionalTokens'
     ].forEach(deploy);

--- a/migrations-ts/1-deploy-contracts.ts
+++ b/migrations-ts/1-deploy-contracts.ts
@@ -13,7 +13,6 @@ module.exports = function(deployer: Truffle.Deployer, network: string) {
       'DefaultCallbackHandler',
       'Multistep',
       'DailyLimitModule',
-      'SocialRecoveryModule',
       'ERC20Mintable',
       'ConditionalTokens'
     ].forEach(deploy);

--- a/migrations/1-deploy-contracts.js
+++ b/migrations/1-deploy-contracts.js
@@ -10,6 +10,7 @@ module.exports = function (deployer, network) {
             'MultiSend',
             'DefaultCallbackHandler',
             'Multistep',
+            'DailyLimitModule',
             'ERC20Mintable',
             'ConditionalTokens'
         ].forEach(deploy);

--- a/migrations/1-deploy-contracts.js
+++ b/migrations/1-deploy-contracts.js
@@ -11,7 +11,6 @@ module.exports = function (deployer, network) {
             'DefaultCallbackHandler',
             'Multistep',
             'DailyLimitModule',
-            'SocialRecoveryModule',
             'ERC20Mintable',
             'ConditionalTokens'
         ].forEach(deploy);

--- a/migrations/1-deploy-contracts.js
+++ b/migrations/1-deploy-contracts.js
@@ -11,6 +11,7 @@ module.exports = function (deployer, network) {
             'DefaultCallbackHandler',
             'Multistep',
             'DailyLimitModule',
+            'SocialRecoveryModule',
             'ERC20Mintable',
             'ConditionalTokens'
         ].forEach(deploy);

--- a/src/CPK.ts
+++ b/src/CPK.ts
@@ -302,14 +302,21 @@ class CPK {
   }
 
   async getModules(): Promise<Address[]> {
+    const isProxyDeployed = await this.isProxyDeployed()
+    if (!isProxyDeployed) {
+      throw new Error('CPK Proxy contract is not deployed')
+    }
     if (!this.#contract) {
       throw new Error('CPK contract uninitialized')
     }
-    const modules = await this.#contract.call('getModules', [])
-    return modules
+    return await this.#contract.call('getModules', [])
   }
 
   async isModuleEnabled(moduleAddress: Address): Promise<boolean> {
+    const isProxyDeployed = await this.isProxyDeployed()
+    if (!isProxyDeployed) {
+      throw new Error('CPK Proxy contract is not deployed')
+    }
     if (!this.#contract) {
       throw new Error('CPK contract uninitialized')
     }
@@ -337,6 +344,10 @@ class CPK {
   }
 
   async disableModule(moduleAddress: Address): Promise<TransactionResult | void> {
+    const isProxyDeployed = await this.isProxyDeployed()
+    if (!isProxyDeployed) {
+      throw new Error('CPK Proxy contract is not deployed')
+    }
     if (!this.#contract) {
       throw new Error('CPK contract uninitialized')
     }

--- a/src/CPK.ts
+++ b/src/CPK.ts
@@ -126,6 +126,20 @@ class CPK {
     }
   }
 
+  async isProxyDeployed(): Promise<boolean> {
+    if (!this.address) {
+      throw new Error('CPK address uninitialized')
+    }
+    if (!this.ethLibAdapter) {
+      throw new Error('CPK ethLibAdapter uninitialized')
+    }
+
+    const codeAtAddress = await this.ethLibAdapter.getCode(this.address)
+    const isDeployed = codeAtAddress !== '0x'
+
+    return isDeployed
+  }
+
   isSafeApp(): boolean {
     return this.#safeAppsSdkConnector.isSafeApp()
   }

--- a/src/CPK.ts
+++ b/src/CPK.ts
@@ -320,14 +320,14 @@ class CPK {
     return selectedModules.length > 0
   }
 
-  async enableModule(moduleAddress: Address): Promise<void> {
+  async enableModule(moduleAddress: Address): Promise<TransactionResult | void> {
     if (!this.#contract) {
       throw new Error('CPK contract uninitialized')
     }
     if (!this.address) {
       throw new Error('CPK address uninitialized')
     }
-    const txResult = await this.execTransactions([
+    return await this.execTransactions([
       {
         to: this.address,
         data: await this.#contract.encode('enableModule', [moduleAddress]),
@@ -336,7 +336,7 @@ class CPK {
     ])
   }
 
-  async disableModule(moduleAddress: Address): Promise<void> {
+  async disableModule(moduleAddress: Address): Promise<TransactionResult | void> {
     if (!this.#contract) {
       throw new Error('CPK contract uninitialized')
     }
@@ -348,7 +348,7 @@ class CPK {
       (module: Address) => module.toLowerCase() === moduleAddress.toLowerCase()
     )
     const prevModuleAddress = index === 0 ? sentinelModules : modules[index - 1]
-    const txResult = await this.execTransactions([
+    return await this.execTransactions([
       {
         to: this.address,
         data: await this.#contract.encode('disableModule', [prevModuleAddress, moduleAddress]),

--- a/src/CPK.ts
+++ b/src/CPK.ts
@@ -9,7 +9,7 @@ import multiSendAbi from './abis/MultiSendAbi.json'
 import { Address } from './utils/basicTypes'
 import { predeterminedSaltNonce } from './utils/constants'
 import { joinHexData, getHexDataLength } from './utils/hexData'
-import { OperationType, standardizeSafeAppsTransaction } from './utils/transactions'
+import { OperationType, SendOptions, standardizeSafeAppsTransaction } from './utils/transactions'
 import {
   Transaction,
   TransactionResult,
@@ -299,6 +299,34 @@ class CPK {
       isConnectedToSafe: this.#isConnectedToSafe,
       sendOptions
     })
+  }
+
+  async getEnabledSafeModules(): Promise<Address[]> {
+    if (!this.#contract) {
+      throw new Error('CPK contract uninitialized')
+    }
+    return this.#contract.call('getModules', [])
+  }
+
+  async isSafeModuleEnabled(moduleAddress: Address): Promise<boolean> {
+    if (!this.#contract) {
+      throw new Error('CPK contract uninitialized')
+    }
+    return this.#contract.call('isModuleEnabled', [moduleAddress])
+  }
+
+  async enableSafeModule(moduleAddress: Address): Promise<TransactionResult> {
+    if (!this.#contract) {
+      throw new Error('CPK contract uninitialized')
+    }
+    return this.#contract.send('enableModule', [moduleAddress])
+  }
+
+  async disableSafeModule(moduleAddress: Address): Promise<TransactionResult> {
+    if (!this.#contract) {
+      throw new Error('CPK contract uninitialized')
+    }
+    return this.#contract.send('disableModule', [moduleAddress])
   }
 
   private getSafeExecTxParams(transactions: Transaction[]): StandardTransaction {

--- a/src/CPK.ts
+++ b/src/CPK.ts
@@ -305,28 +305,57 @@ class CPK {
     if (!this.#contract) {
       throw new Error('CPK contract uninitialized')
     }
-    return this.#contract.call('getModules', [])
+    const modules = await this.#contract.call('getModules', [])
+    return modules
   }
 
   async isSafeModuleEnabled(moduleAddress: Address): Promise<boolean> {
     if (!this.#contract) {
       throw new Error('CPK contract uninitialized')
     }
-    return this.#contract.call('isModuleEnabled', [moduleAddress])
+    const modules = await this.#contract.call('getModules', [])
+    const selectedModules = modules.filter(
+      (mod: Address) => mod.toLowerCase() === moduleAddress.toLocaleLowerCase()
+    )
+    return selectedModules.length > 0
   }
 
-  async enableSafeModule(moduleAddress: Address): Promise<TransactionResult> {
+  async enableSafeModule(
+    moduleAddress: Address,
+    options?: ExecOptions
+  ): Promise<TransactionResult> {
     if (!this.#contract) {
       throw new Error('CPK contract uninitialized')
     }
-    return this.#contract.send('enableModule', [moduleAddress])
+    const ownerAccount = await this.getOwnerAccount()
+    if (!ownerAccount) {
+      throw new Error('CPK ownerAccount uninitialized')
+    }
+    const sendOptions = normalizeGasLimit({ ...options, from: ownerAccount })
+    const txResult = await this.#contract.send('enableModule', [moduleAddress], {
+      ...sendOptions,
+      from: ownerAccount
+    })
+    return txResult
   }
 
-  async disableSafeModule(moduleAddress: Address): Promise<TransactionResult> {
+  async disableSafeModule(
+    moduleAddress: Address,
+    options?: ExecOptions
+  ): Promise<TransactionResult> {
     if (!this.#contract) {
       throw new Error('CPK contract uninitialized')
     }
-    return this.#contract.send('disableModule', [moduleAddress])
+    const ownerAccount = await this.getOwnerAccount()
+    if (!ownerAccount) {
+      throw new Error('CPK ownerAccount uninitialized')
+    }
+    const sendOptions = normalizeGasLimit({ ...options, from: ownerAccount })
+    const txResult = await this.#contract.send('disableModule', [moduleAddress], {
+      ...sendOptions,
+      from: ownerAccount
+    })
+    return txResult
   }
 
   private getSafeExecTxParams(transactions: Transaction[]): StandardTransaction {

--- a/src/CPK.ts
+++ b/src/CPK.ts
@@ -301,7 +301,7 @@ class CPK {
     })
   }
 
-  async getEnabledSafeModules(): Promise<Address[]> {
+  async getModules(): Promise<Address[]> {
     if (!this.#contract) {
       throw new Error('CPK contract uninitialized')
     }
@@ -309,7 +309,7 @@ class CPK {
     return modules
   }
 
-  async isSafeModuleEnabled(moduleAddress: Address): Promise<boolean> {
+  async isModuleEnabled(moduleAddress: Address): Promise<boolean> {
     if (!this.#contract) {
       throw new Error('CPK contract uninitialized')
     }
@@ -320,7 +320,7 @@ class CPK {
     return selectedModules.length > 0
   }
 
-  async enableSafeModule(moduleAddress: Address): Promise<void> {
+  async enableModule(moduleAddress: Address): Promise<void> {
     if (!this.#contract) {
       throw new Error('CPK contract uninitialized')
     }
@@ -336,7 +336,7 @@ class CPK {
     ])
   }
 
-  async disableSafeModule(moduleAddress: Address): Promise<void> {
+  async disableModule(moduleAddress: Address): Promise<void> {
     if (!this.#contract) {
       throw new Error('CPK contract uninitialized')
     }

--- a/src/CPK.ts
+++ b/src/CPK.ts
@@ -327,7 +327,7 @@ class CPK {
     return selectedModules.length > 0
   }
 
-  async enableModule(moduleAddress: Address): Promise<TransactionResult | void> {
+  async enableModule(moduleAddress: Address): Promise<TransactionResult> {
     if (!this.#contract) {
       throw new Error('CPK contract uninitialized')
     }
@@ -343,7 +343,7 @@ class CPK {
     ])
   }
 
-  async disableModule(moduleAddress: Address): Promise<TransactionResult | void> {
+  async disableModule(moduleAddress: Address): Promise<TransactionResult> {
     const isProxyDeployed = await this.isProxyDeployed()
     if (!isProxyDeployed) {
       throw new Error('CPK Proxy contract is not deployed')

--- a/src/abis/SafeAbi.json
+++ b/src/abis/SafeAbi.json
@@ -229,5 +229,55 @@
     "payable": false,
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getModules",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract Module",
+        "name": "module",
+        "type": "address"
+      }
+    ],
+    "name": "enableModule",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract Module",
+        "name": "prevModule",
+        "type": "address"
+      },
+      {
+        "internalType": "contract Module",
+        "name": "module",
+        "type": "address"
+      }
+    ],
+    "name": "disableModule",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
   }
 ]

--- a/src/ethLibAdapters/EthersAdapter/index.ts
+++ b/src/ethLibAdapters/EthersAdapter/index.ts
@@ -155,13 +155,6 @@ class EthersAdapter extends EthLibAdapter {
       })
     )
   }
-
-  getSendOptions(ownerAccount: Address, options?: CallOptions): SendOptions {
-    return {
-      from: ownerAccount,
-      ...options
-    }
-  }
 }
 
 export default EthersAdapter

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,6 +2,8 @@ import { OperationType } from './transactions'
 
 export const zeroAddress = `0x${'0'.repeat(40)}`
 
+export const sentinelModules = '0x0000000000000000000000000000000000000001'
+
 export const defaultTxOperation = OperationType.Call
 export const defaultTxValue = 0
 export const defaultTxData = '0x'

--- a/test/ethers/shouldWorkWithEthers.ts
+++ b/test/ethers/shouldWorkWithEthers.ts
@@ -1,6 +1,6 @@
 import should from 'should'
 import Web3Maj1Min3 from 'web3-1-3'
-import CPK, { NetworksConfig, EthersAdapter, TransactionManager, Transaction } from '../../src'
+import CPK, { NetworksConfig, EthersAdapter, TransactionManager, Transaction, TransactionResult } from '../../src'
 import { Address } from '../../src/utils/basicTypes'
 import { testSafeTransactions } from '../transactions/testSafeTransactions'
 import { testConnectedSafeTransactionsWithRelay } from '../transactions/testConnectedSafeTransactionsWithRelay'
@@ -88,7 +88,7 @@ export function shouldWorkWithEthers({
         should.exist(transactionResponse)
         should.exist(hash)
       },
-      waitTxReceipt: ({ hash }: { hash: string }): any => signer.provider.waitForTransaction(hash)
+      waitTxReceipt: (txResult: TransactionResult): any => signer.provider.waitForTransaction(txResult.hash)
     })
 
     before('setup contracts', async () => {
@@ -166,7 +166,7 @@ export function shouldWorkWithEthers({
             web3.eth.sendTransaction({
               from: defaultAccountBox[0],
               to: signer.address,
-              value: `${2e18}`,
+              value: `${3e18}`,
               gas: '0x5b8d80'
             })
           )
@@ -186,7 +186,7 @@ export function shouldWorkWithEthers({
               web3.eth.sendTransaction({
                 from: defaultAccountBox[0],
                 to: cpk.address,
-                value: `${2e18}`
+                value: `${3e18}`
               })
             )
           }
@@ -226,7 +226,7 @@ export function shouldWorkWithEthers({
               web3.eth.sendTransaction({
                 from: defaultAccountBox[0],
                 to: freshSignerBox[0].address,
-                value: `${2e18}`,
+                value: `${3e18}`,
                 gas: '0x5b8d80'
               })
             )
@@ -258,7 +258,7 @@ export function shouldWorkWithEthers({
               web3.eth.sendTransaction({
                 from: defaultAccountBox[0],
                 to: cpk.address,
-                value: `${2e18}`
+                value: `${3e18}`
               })
             )
           }

--- a/test/transactions/testSafeTransactions.ts
+++ b/test/transactions/testSafeTransactions.ts
@@ -345,6 +345,13 @@ export function testSafeTransactions({
         moduleList.length.should.equal(0)
         ;(await cpk.isModuleEnabled(dailyLimitModule.address)).should.equal(false)
         ;(await cpk.isModuleEnabled(socialRecoveryModule.address)).should.equal(false)
+      } else {
+        await sendTransaction({
+          from: await cpk.getOwnerAccount(),
+          to: cpk.address,
+          value: '0xde0b6b3a7640000',
+          gas: '0x5b8d80'
+        })
       }
 
       await waitTxReceipt(await cpk.enableModule(dailyLimitModule.address))

--- a/test/transactions/testSafeTransactions.ts
+++ b/test/transactions/testSafeTransactions.ts
@@ -61,7 +61,6 @@ export function testSafeTransactions({
     let multiStep: any
     let erc20: any
     let dailyLimitModule: any
-    let socialRecoveryModule: any
 
     beforeEach('rebind symbols', async () => {
       cpk = await getCPK()
@@ -73,7 +72,6 @@ export function testSafeTransactions({
     before('deploy conditional tokens and daily limit module', async () => {
       conditionalTokens = await getContracts().ConditionalTokens.new()
       dailyLimitModule = await getContracts().DailyLimitModule.new()
-      socialRecoveryModule = await getContracts().SocialRecoveryModule.new()
     })
 
     beforeEach('deploy mock contracts', async () => {
@@ -344,7 +342,6 @@ export function testSafeTransactions({
         moduleList = await cpk.getModules()
         moduleList.length.should.equal(0)
         ;(await cpk.isModuleEnabled(dailyLimitModule.address)).should.equal(false)
-        ;(await cpk.isModuleEnabled(socialRecoveryModule.address)).should.equal(false)
       } else {
         await sendTransaction({
           from: await cpk.getOwnerAccount(),
@@ -359,36 +356,19 @@ export function testSafeTransactions({
       moduleList = await cpk.getModules()
       moduleList.length.should.equal(1)
       ;(await cpk.isModuleEnabled(dailyLimitModule.address)).should.equal(true)
-      ;(await cpk.isModuleEnabled(socialRecoveryModule.address)).should.equal(false)
-
-      await waitTxReceipt(await cpk.enableModule(socialRecoveryModule.address))
-
-      moduleList = await cpk.getModules()
-      moduleList.length.should.equal(2)
-      ;(await cpk.isModuleEnabled(dailyLimitModule.address)).should.equal(true)
-      ;(await cpk.isModuleEnabled(socialRecoveryModule.address)).should.equal(true)
     })
     ;(accountType === AccountType.Fresh ? it.skip : it)('can disable modules', async () => {
       let moduleList: Address[]
 
       moduleList = await cpk.getModules()
-      moduleList.length.should.equal(2)
+      moduleList.length.should.equal(1)
       ;(await cpk.isModuleEnabled(dailyLimitModule.address)).should.equal(true)
-      ;(await cpk.isModuleEnabled(socialRecoveryModule.address)).should.equal(true)
 
       await waitTxReceipt(await cpk.disableModule(dailyLimitModule.address))
 
       moduleList = await cpk.getModules()
-      moduleList.length.should.equal(1)
-      ;(await cpk.isModuleEnabled(dailyLimitModule.address)).should.equal(false)
-      ;(await cpk.isModuleEnabled(socialRecoveryModule.address)).should.equal(true)
-
-      await waitTxReceipt(await cpk.disableModule(socialRecoveryModule.address))
-
-      moduleList = await cpk.getModules()
       moduleList.length.should.equal(0)
       ;(await cpk.isModuleEnabled(dailyLimitModule.address)).should.equal(false)
-      ;(await cpk.isModuleEnabled(socialRecoveryModule.address)).should.equal(false)
     })
   })
 }

--- a/test/utils/contracts.ts
+++ b/test/utils/contracts.ts
@@ -9,6 +9,7 @@ import MultistepJson from '../../build/contracts/Multistep.json'
 import ERC20MintableJson from '../../build/contracts/ERC20Mintable.json'
 import ConditionalTokensJson from '../../build/contracts/ConditionalTokens.json'
 import DailyLimitModuleJson from '../../build/contracts/DailyLimitModule.json'
+import SocialRecoveryModuleJson from '../../build/contracts/SocialRecoveryModule.json'
 import { Address } from '../../src/utils/basicTypes'
 
 let CPKFactory: any
@@ -20,6 +21,7 @@ let MultiStep: any
 let ERC20Mintable: any
 let ConditionalTokens: any
 let DailyLimitModule: any
+let SocialRecoveryModule: any
 
 let cpkFactory: any
 let gnosisSafe: any
@@ -30,6 +32,7 @@ let multiStep: any
 let erc20: any
 let conditionalTokens: any
 let dailyLimitModule: any
+let socialRecoveryModule: any
 
 export interface TestContractInstances {
   cpkFactory: any
@@ -41,6 +44,7 @@ export interface TestContractInstances {
   erc20: any
   conditionalTokens: any
   dailyLimitModule: any
+  socialRecoveryModule: any
 }
 
 export interface TestContracts {
@@ -53,6 +57,7 @@ export interface TestContracts {
   ERC20Mintable: any
   ConditionalTokens: any
   DailyLimitModule: any
+  SocialRecoveryModule: any
 }
 
 export const initializeContracts = async (safeOwner: Address): Promise<void> => {
@@ -102,6 +107,11 @@ export const initializeContracts = async (safeOwner: Address): Promise<void> => 
   DailyLimitModule.setProvider(provider)
   DailyLimitModule.defaults({ from: safeOwner })
   dailyLimitModule = await DailyLimitModule.deployed()
+
+  SocialRecoveryModule = TruffleContract(SocialRecoveryModuleJson)
+  SocialRecoveryModule.setProvider(provider)
+  SocialRecoveryModule.defaults({ from: safeOwner })
+  socialRecoveryModule = await SocialRecoveryModule.deployed()
 }
 
 export const getContracts = (): TestContracts => ({
@@ -113,7 +123,8 @@ export const getContracts = (): TestContracts => ({
   MultiStep,
   ERC20Mintable,
   ConditionalTokens,
-  DailyLimitModule
+  DailyLimitModule,
+  SocialRecoveryModule
 })
 
 export const getContractInstances = (): TestContractInstances => ({
@@ -125,5 +136,6 @@ export const getContractInstances = (): TestContractInstances => ({
   multiStep,
   erc20,
   conditionalTokens,
-  dailyLimitModule
+  dailyLimitModule,
+  socialRecoveryModule
 })

--- a/test/utils/contracts.ts
+++ b/test/utils/contracts.ts
@@ -9,7 +9,6 @@ import MultistepJson from '../../build/contracts/Multistep.json'
 import ERC20MintableJson from '../../build/contracts/ERC20Mintable.json'
 import ConditionalTokensJson from '../../build/contracts/ConditionalTokens.json'
 import DailyLimitModuleJson from '../../build/contracts/DailyLimitModule.json'
-import SocialRecoveryModuleJson from '../../build/contracts/SocialRecoveryModule.json'
 import { Address } from '../../src/utils/basicTypes'
 
 let CPKFactory: any
@@ -21,7 +20,6 @@ let MultiStep: any
 let ERC20Mintable: any
 let ConditionalTokens: any
 let DailyLimitModule: any
-let SocialRecoveryModule: any
 
 let cpkFactory: any
 let gnosisSafe: any
@@ -32,7 +30,6 @@ let multiStep: any
 let erc20: any
 let conditionalTokens: any
 let dailyLimitModule: any
-let socialRecoveryModule: any
 
 export interface TestContractInstances {
   cpkFactory: any
@@ -44,7 +41,6 @@ export interface TestContractInstances {
   erc20: any
   conditionalTokens: any
   dailyLimitModule: any
-  socialRecoveryModule: any
 }
 
 export interface TestContracts {
@@ -57,7 +53,6 @@ export interface TestContracts {
   ERC20Mintable: any
   ConditionalTokens: any
   DailyLimitModule: any
-  SocialRecoveryModule: any
 }
 
 export const initializeContracts = async (safeOwner: Address): Promise<void> => {
@@ -107,11 +102,6 @@ export const initializeContracts = async (safeOwner: Address): Promise<void> => 
   DailyLimitModule.setProvider(provider)
   DailyLimitModule.defaults({ from: safeOwner })
   dailyLimitModule = await DailyLimitModule.deployed()
-
-  SocialRecoveryModule = TruffleContract(SocialRecoveryModuleJson)
-  SocialRecoveryModule.setProvider(provider)
-  SocialRecoveryModule.defaults({ from: safeOwner })
-  socialRecoveryModule = await SocialRecoveryModule.deployed()
 }
 
 export const getContracts = (): TestContracts => ({
@@ -124,7 +114,6 @@ export const getContracts = (): TestContracts => ({
   ERC20Mintable,
   ConditionalTokens,
   DailyLimitModule,
-  SocialRecoveryModule
 })
 
 export const getContractInstances = (): TestContractInstances => ({
@@ -137,5 +126,4 @@ export const getContractInstances = (): TestContractInstances => ({
   erc20,
   conditionalTokens,
   dailyLimitModule,
-  socialRecoveryModule
 })

--- a/test/utils/contracts.ts
+++ b/test/utils/contracts.ts
@@ -8,6 +8,7 @@ import ProxyFactoryJson from '../../build/contracts/ProxyFactory.json'
 import MultistepJson from '../../build/contracts/Multistep.json'
 import ERC20MintableJson from '../../build/contracts/ERC20Mintable.json'
 import ConditionalTokensJson from '../../build/contracts/ConditionalTokens.json'
+import DailyLimitModuleJson from '../../build/contracts/DailyLimitModule.json'
 import { Address } from '../../src/utils/basicTypes'
 
 let CPKFactory: any
@@ -18,6 +19,7 @@ let DefaultCallbackHandler: any
 let MultiStep: any
 let ERC20Mintable: any
 let ConditionalTokens: any
+let DailyLimitModule: any
 
 let cpkFactory: any
 let gnosisSafe: any
@@ -27,6 +29,7 @@ let defaultCallbackHandler: any
 let multiStep: any
 let erc20: any
 let conditionalTokens: any
+let dailyLimitModule: any
 
 export interface TestContractInstances {
   cpkFactory: any
@@ -37,6 +40,7 @@ export interface TestContractInstances {
   multiStep: any
   erc20: any
   conditionalTokens: any
+  dailyLimitModule: any
 }
 
 export interface TestContracts {
@@ -48,6 +52,7 @@ export interface TestContracts {
   MultiStep: any
   ERC20Mintable: any
   ConditionalTokens: any
+  DailyLimitModule: any
 }
 
 export const initializeContracts = async (safeOwner: Address): Promise<void> => {
@@ -92,6 +97,11 @@ export const initializeContracts = async (safeOwner: Address): Promise<void> => 
   ConditionalTokens.setProvider(provider)
   ConditionalTokens.defaults({ from: safeOwner })
   conditionalTokens = await ConditionalTokens.deployed()
+
+  DailyLimitModule = TruffleContract(DailyLimitModuleJson)
+  DailyLimitModule.setProvider(provider)
+  DailyLimitModule.defaults({ from: safeOwner })
+  dailyLimitModule = await DailyLimitModule.deployed()
 }
 
 export const getContracts = (): TestContracts => ({
@@ -102,7 +112,8 @@ export const getContracts = (): TestContracts => ({
   DefaultCallbackHandler,
   MultiStep,
   ERC20Mintable,
-  ConditionalTokens
+  ConditionalTokens,
+  DailyLimitModule
 })
 
 export const getContractInstances = (): TestContractInstances => ({
@@ -113,5 +124,6 @@ export const getContractInstances = (): TestContractInstances => ({
   defaultCallbackHandler,
   multiStep,
   erc20,
-  conditionalTokens
+  conditionalTokens,
+  dailyLimitModule
 })

--- a/test/web3/shouldWorkWithWeb3.ts
+++ b/test/web3/shouldWorkWithWeb3.ts
@@ -55,11 +55,11 @@ export function shouldWorkWithWeb3({
       checkTxObj: (txResult: TransactionResult): void => {
         should.exist(txResult.hash)
       },
-      waitTxReceipt: async ({ hash }: { hash: string }): Promise<any> => {
-        let receipt = await web3Box[0].eth.getTransactionReceipt(hash)
+      waitTxReceipt: async (txResult: TransactionResult): Promise<any> => {
+        let receipt = await web3Box[0].eth.getTransactionReceipt(txResult.hash)
         while (!receipt) {
           await new Promise((resolve) => setTimeout(resolve, 50))
-          receipt = await web3Box[0].eth.getTransactionReceipt(hash)
+          receipt = await web3Box[0].eth.getTransactionReceipt(txResult.hash)
         }
         return receipt
       }

--- a/test/web3/shouldWorkWithWeb3.ts
+++ b/test/web3/shouldWorkWithWeb3.ts
@@ -160,7 +160,7 @@ export function shouldWorkWithWeb3({
             await ueb3TestHelpers.sendTransaction({
               from: defaultAccountBox[0],
               to: cpk.address,
-              value: `${2e18}`
+              value: `${3e18}`
             })
           }
         })
@@ -195,7 +195,7 @@ export function shouldWorkWithWeb3({
             await ueb3TestHelpers.sendTransaction({
               from: defaultAccountBox[0],
               to: newAccount.address,
-              value: `${2e18}`,
+              value: `${3e18}`,
               gas: '0x5b8d80'
             })
 
@@ -230,7 +230,7 @@ export function shouldWorkWithWeb3({
             await ueb3TestHelpers.sendTransaction({
               from: defaultAccountBox[0],
               to: cpk.address,
-              value: `${2e18}`
+              value: `${3e18}`
             })
           }
         })


### PR DESCRIPTION
Check https://github.com/gnosis/contract-proxy-kit/issues/89


The following methods won't be added for now until the new CPKFactory contract is available:
- transfer ETH out of the GnosisSafeProxy: `cpk.transfer(destination, amountInWei)`
- send ETH along with `execTransactions`: `cpk.execTransactions(txs, {value})`