### PR TITLE
Fix EthersAdapter.getBalance

### DIFF
--- a/packages/contract-proxy-kit/src/ethLibAdapters/EthersAdapter/index.ts
+++ b/packages/contract-proxy-kit/src/ethLibAdapters/EthersAdapter/index.ts
@@ -98,7 +98,7 @@ class EthersAdapter extends EthLibAdapter {
    * @returns The balance of the address
    */
   async getBalance(address: Address): Promise<BigNumber> {
-    return new BigNumber(await this.signer.provider.getBalance(address))
+    return await this.signer.provider.getBalance(address)
   }
 
   /**


### PR DESCRIPTION
This PR fixes a NaN error when calling `CPK.getBalance()` using EthersJS (EthersAdapter) provider

Reason: the `signer.provider.getBalance` method already returns a BigNumber